### PR TITLE
📈: Add a workflow to label pull requests

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,49 @@
+# Add 'iOS' label to any change within the 'ios' directory
+iOS:
+  - ios/**/*
+
+# Add 'Android' label to any change within the 'android' directory
+Android:
+  - android/**/*
+
+# Add 'app' label to any change within the 'app' directory and to the files listed below
+app:
+  - app/**/*
+  - app.json
+  - index.js
+
+# Add 'build' label to any changes to the files listed below
+build:
+  - .buckconfig
+  - .editorconfig
+  - .eslintrc.js
+  - .prettierrc.js
+  - babel.config.js
+  - metro.config.js
+  - package.json
+  - package-lock.json
+  - tsconfig.json
+
+# Add 'chore' label to any change within the '.github' directory and to the files listed below
+chore:
+  # Changes to files within '.github/workflows' should correspond to the 'ci' label
+  - any: ['.github/**/*', '!.github/workflows/**/*']
+  - .gitattributes
+  - .gitignore
+  - gitignore
+  - LICENSE
+
+# Add 'ci' label to any change within the '.github/workflows' directory
+ci:
+  - .github/workflows/**/*
+
+# Add 'doc' label to any change within the 'docs' directory
+doc:
+  - docs/**/*
+  - README.md
+
+# Add 'test' label to any change to files within the directories listed below
+test:
+  - __tests__/**/*
+  - __mocks__/**/*
+  - jest.config.js

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Label according to modified files
         # https://github.com/marketplace/actions/labeler
-        uses: actions/labeler@2.2.0
+        uses: actions/labeler@master
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           # Default is '.github/labeler.yml', but we use 'yaml' as an extension of YAML files.

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,7 +1,11 @@
 name: Triage
 
 on:
-  - pull_request_target
+  pull_request:
+    types:
+      - opend
+      - edited
+      - reopened
 
 jobs:
   triage:

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,18 @@
+name: Triage
+
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label according to modified files
+        # https://github.com/marketplace/actions/labeler
+        uses: actions/labeler@2.2.0
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          # Default is '.github/labeler.yml', but we use 'yaml' as an extension of YAML files.
+          configuration-path: '.github/labeler.yaml'
+          # Remove labels when matching files are reverted or no longer changed by the PR
+          sync-labels: true


### PR DESCRIPTION
## やったこと

- [x] Automatically add label to pull requests based on modified files.
  - `iOS`, `Android`, `app`, `build`, `chore`, `ci`, `doc`, `test`

## やっていないこと

Nothing

## 動作確認

- [x] This pull request is labeled as `chore` and `ci`

## デバイス

It's not about the devices.

## その他（レビュアーへの申し送り事項、懸念点など）

I can't think of anything.