### PR TITLE
🔨: Add TypeScript lint and test workflow to GitHub Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,11 +4,19 @@ root = true
 
 [*.{ts,tsx,js,jsx,json}]
 
+# インデントにはスペースを利用する。
 indent_style = space
+# インデントサイズは2。
 indent_size = 2
+# タブ文字は8文字幅で表示する。（Tabが紛れていることがわかりやすくなるように）
 tab_width = 8
+# 改行コードはLFに統一する。（batなど一部のファイルの改行コードは.gitattributesで強制的にCRLFに変更されます。）
 end_of_line = lf
+# 文字コードはUTF-8
 charset = utf-8
+# 行末の空白はトリムする。
 trim_trailing_whitespace = true
+# ファイル末尾に改行を入れる。
 insert_final_newline = true
+# 一行の長さは150文字まで。
 max_line_length = 150

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -1,0 +1,101 @@
+name: TypeScript
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'app/**'
+      - '__tests__/**'
+      - '__mocks__/**'
+      - 'app.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '.editorconfig'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'app/**'
+      - '__tests__/**'
+      - '__mocks__/**'
+      - 'app.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '.editorconfig'
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  lint-and-test:
+    name: Run lint and test
+    runs-on: macos-latest
+    env:
+      REVIEWDOG_GITHUB_API_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Cache '.npm' to speed up clean-install when package-lock.json is updated.
+      # Loosened up the restore-keys a bit, as it doesn't have to match the contents of package-lock.json exactly.
+      - name: Cache .npm
+        id: cache-npm
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          # If cache is corrupted, increment prefixed number.
+          key: 1-${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            1-${{ runner.os }}-npm-
+
+      # If package-lock.json matches, node_modules will also match.
+      # So, cache node_modules directly to skip install step.
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          # If cache is corrupted, increment prefixed number.
+          key: 1-${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+
+      # node_modulesがキャッシュから復元されなかった場合は、依存ライブラリをインストールします。
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm clean-install
+
+      - name: Set up reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Lint (ESLint)
+        run: |
+          npm run -s lint:es | reviewdog -tee -fail-on-error -reporter=github-pr-review -f=eslint -name="ESLint"
+
+      - name: Lint (TypeScript)
+        run: |
+          npm run -s lint:tsc | reviewdog -tee -fail-on-error -reporter=github-pr-review -f=tsc -name="TypeScript"
+
+      - name: Test
+        run: |
+          npm run -s test -- --ci --reporters=default --reporters=jest-junit
+
+      - name: Report test result
+        uses: ashley-taylor/junit-report-annotations-action@master
+        if: always()
+        with:
+          access-token: ${{ secrets.GITHUB_TOKEN }}
+          name: Test results
+          path: junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ buck-out/
 # Expo
 .expo/*
 web-build/
+
+# Jest
+junit.xml

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,15 @@
+// https://prettier.io/docs/en/options.html
 module.exports = {
+  // https://prettier.io/docs/en/options.html#bracket-spacing
+  // import {React} from 'React' のように、{}の間にスペースを含まないようにする。
   bracketSpacing: false,
+  // https://prettier.io/docs/en/options.html#jsx-brackets
+  // JSXのタグが複数行になったときに、最後の'>'の前で改行しない。
   jsxBracketSameLine: true,
+  // https://prettier.io/docs/en/options.html#quotes
+  // ダブルクオートではなく、シングルクオートに統一する。
   singleQuote: true,
+  // https://prettier.io/docs/en/options.html#trailing-commas
+  // 配列などの最後の要素の後にもカンマを付けるようにする。（順番を入れ替えたりするときに行を入れ替えるだけで良くなるので便利です。）
   trailingComma: 'all',
 };

--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
-# ws-4020 React Native starter
+# RN Spoiler
 
 [Expo](https://expo.io/) の [expo-template-bare-typescript](https://github.com/expo/expo/tree/master/templates/expo-template-bare-typescript) をベースにしたReact Nativeのテンプレートです。
 
 ## 前提条件
 
 * [React Nativeの開発環境が構築](https://reactnative.dev/docs/environment-setup)されていること
-  * **必ず「React Native CLI Quickstart」というタブをクリック**して、手順を確認してください。
-  * 「Development OS」は、使っているOSを選択してください。
+  * **必ず「React Native CLI Quickstart」というタブをクリック**して、手順を実施してください。
+  * 「Development OS」は、開発に利用しているOSを選択してください。
   * （macOSのみ）「Target OS」は、「iOS」「Android」の両方の手順を実施してください。
 
 ## 使い方
 
 ### 新規プロジェクトの作成
 
-以下のコマンドを実行して、新規プロジェクトを作成できます。
+次のコマンドを実行して、新規プロジェクトを作成できます。
 
 ```bash
 expo init -t https://github.com/ws-4020/react-native-starter.git <YourAppName>
 ```
 
 `<YourAppName>` に設定した名前でディレクトリが作成されて、Gitリポジトリとして初期化されます。Gitリポジトリにする必要がない場合は`.git`ディレクトリを削除してください。
+また、テンプレートプロジェクト自体のために`.github`ディレクトリを用意していますが、プロジェクトで不要であれば削除してください。
 
 正しく生成できていることを確認するために、次のコマンドを実行してアプリが正しく起動することを確認してください。
 
@@ -34,37 +35,68 @@ npm run android // Androidエミュレータが起動します
 Managed Workflowのドキュメントではありますが、Bare Workflowを採用しているこのテンプレートを利用する場合でも参考になります。
 
 * [Deploying to App Stores - Expo](https://docs.expo.io/distribution/app-stores/)
-  * このテンプレートではBare Workflowを採用しているため、`app.json` の `ios`と`android` に関する設定は、`Info.plist`や`AndroidManifest.xml`などで設定する必要があります
+  * このテンプレートではBare Workflowを採用しているため、`app.json`の`ios`と`android`に関する設定は、`Info.plist`や`AndroidManifest.xml`などで設定する必要があります
   * Managed WorkflowとBare Workflowの違いについては [Workflows - Expo Documentation](https://docs.expo.io/introduction/managed-vs-bare/) を参照してください
 
 ### ソースコードのスタイルなどをチェックする
 
 詳細に定義されたコーディング規約を意識しながらコードを書くのではなく、自動的にコードのスタイルなどをチェックしてくれるツールを活用してください。
-このテンプレートでは、そういった支援をしてくれる、以下のツールを導入しています。
+このテンプレートでは、そういった支援をしてくれるツールを導入しています。必要に応じて、各設定ファイルを編集して好みの設定に調整してください。
+
+次のコマンドを実行すると、すべてのツールでのチェックが実行されます。
+
+```bash
+npm run -s lint
+```
+
+ツールに定型的な修正を実行させるには、次のコマンドを実行してください。なお、自動修正が適用できない違反は通常通り報告されます。
+
+```bash
+npm run -s fix
+```
+
+#### ESLint
 
 * [ESLint](https://eslint.org/)
   * 標準的な規約として、[eslint-config-universe](https://github.com/expo/expo/tree/master/packages/eslint-config-universe)を設定してあります。
   * TypeScriptの型に関する規約([@typescript-eslint/recommended-requiring-type-checking](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules))も設定してあります。
     * TypeScriptに慣れていないと、この規約が厳しく感じるかもしれません。実際にコードを書いてみて、対応するのが難しい指摘や効果の薄い指摘は個別にルールを無効化してみてください。
   * 設定を変更したい場合は、ESLintやeslint-config-universeのドキュメントを確認して、`.eslintrc.js`を変更してください。
-* [Prettier](https://prettier.io/)
-  * `.prettierrc.js`に設定を記載しています。内容についてはコメントを確認してください。
-  * 好みの部分が大きいと思うので、
 * [EditorConfig](https://editorconfig.org/)
-  * `.eslintconfig`に設定を記載しています。
+  * 一般的と考えている設定をしています。内容については`.eslintconfig`内のコメントを確認してください。
+* [Prettier](https://prettier.io/)
+  * `npx react-native init`で生成されるものと同じ設定をしています。内容については`.prettierrc.js`内のコメントを確認してください。
+  * EditorConfigの設定も読み込むので、重複する内容を設定する必要はありません。[読み込まれるEditorConfigの設定値](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options)は次のものです。
+    * `end_of_line`
+    * `indent_style`
+    * `indent_size`, `tab_width`
+    * `max_line_length`
 
-規約違反のコードがないかをチェックするには、次のコマンドを実行してください。
+ESLintでのチェックを実行するには、次のコマンドを実行してください。
 
-```
-npm run -s lint
+```bash
+npm run -s lint:es
 ```
 
 定型的な修正はツールが自動的に変更を加えてくれます。自動的に修正したい場合は、次のコマンドを実行してください。すべての違反を修正してくれるわけではありませんが、非常に便利なのでぜひ活用してください。
 
+```bash
+npm run -s fix:es
 ```
-npm run -s lint:fix
+
+#### TypeScript
+
+[TypeScript](https://www.typescriptlang.org/)のコンパイラには、コーディング規約をチェックする機能があります。たとえば、型情報が適切に設定されているかどうかや、import/exportの構文が規約どおりになっているかなどをチェックすることができます。
+
+テンプレートでは、React Native (Expo) での標準的な内容を設定してあります。設定値の詳細については、`tsconfig.json`と[TSConfig Reference](https://www.typescriptlang.org/tsconfig)を参照してください。
+
+TypeScriptコンパイラでの規約チェックを実行するには、次のコマンドを実行してください。
+
+```bash
+npm run -s lint:tsc
 ```
 
 ## `expo-template-bare-typescript` からの変更点
 
-* [ ] Editorconfig, ESLint, Prettierを追加
+* [x] Editorconfig, ESLint, Prettierを追加
+* [x] TypeScriptの設定ファイルを修正、`tsc`での型チェックをlintに追加

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # RN Spoiler
 
-[Expo](https://expo.io/) の [expo-template-bare-typescript](https://github.com/expo/expo/tree/master/templates/expo-template-bare-typescript) をベースにしたReact Nativeのテンプレートです。
+[Expo](https://expo.io/) の [expo-template-bare-typescript](https://github.com/expo/expo/tree/master/templates/expo-template-bare-typescript) をベースにした React Native のテンプレートです。
 
 ## 前提条件
 
-* [React Nativeの開発環境が構築](https://reactnative.dev/docs/environment-setup)されていること
-  * **必ず「React Native CLI Quickstart」というタブをクリック**して、手順を実施してください。
-  * 「Development OS」は、開発に利用しているOSを選択してください。
-  * （macOSのみ）「Target OS」は、「iOS」「Android」の両方の手順を実施してください。
+- [React Native の開発環境が構築](https://reactnative.dev/docs/environment-setup)されていること
+  - **必ず「React Native CLI Quickstart」というタブをクリック**して、手順を実施してください。
+  - 「Development OS」は、開発に利用している OS を選択してください。
+  - （macOS のみ）「Target OS」は、「iOS」「Android」の両方の手順を実施してください。
 
 ## 使い方
 
@@ -19,7 +19,7 @@
 expo init -t https://github.com/ws-4020/react-native-starter.git <YourAppName>
 ```
 
-`<YourAppName>` に設定した名前でディレクトリが作成されて、Gitリポジトリとして初期化されます。Gitリポジトリにする必要がない場合は`.git`ディレクトリを削除してください。
+`<YourAppName>` に設定した名前でディレクトリが作成されて、Git リポジトリとして初期化されます。Git リポジトリにする必要がない場合は`.git`ディレクトリを削除してください。
 また、テンプレートプロジェクト自体のために`.github`ディレクトリを用意していますが、プロジェクトで不要であれば削除してください。
 
 正しく生成できていることを確認するために、次のコマンドを実行してアプリが正しく起動することを確認してください。
@@ -31,12 +31,12 @@ npm run android // Androidエミュレータが起動します
 
 ### アプリの配信準備
 
-アプリの配信までにしなくてはいけない作業がいくつかあるので、Expoのドキュメントを参照してアプリの配信準備をしてください。
-Managed Workflowのドキュメントではありますが、Bare Workflowを採用しているこのテンプレートを利用する場合でも参考になります。
+アプリの配信までにしなくてはいけない作業がいくつかあるので、Expo のドキュメントを参照してアプリの配信準備をしてください。
+Managed Workflow のドキュメントではありますが、Bare Workflow を採用しているこのテンプレートを利用する場合でも参考になります。
 
-* [Deploying to App Stores - Expo](https://docs.expo.io/distribution/app-stores/)
-  * このテンプレートではBare Workflowを採用しているため、`app.json`の`ios`と`android`に関する設定は、`Info.plist`や`AndroidManifest.xml`などで設定する必要があります
-  * Managed WorkflowとBare Workflowの違いについては [Workflows - Expo Documentation](https://docs.expo.io/introduction/managed-vs-bare/) を参照してください
+- [Deploying to App Stores - Expo](https://docs.expo.io/distribution/app-stores/)
+  - このテンプレートでは Bare Workflow を採用しているため、`app.json`の`ios`と`android`に関する設定は、`Info.plist`や`AndroidManifest.xml`などで設定する必要があります
+  - Managed Workflow と Bare Workflow の違いについては [Workflows - Expo Documentation](https://docs.expo.io/introduction/managed-vs-bare/) を参照してください
 
 ### ソースコードのスタイルなどをチェックする
 
@@ -57,22 +57,22 @@ npm run -s fix
 
 #### ESLint
 
-* [ESLint](https://eslint.org/)
-  * 標準的な規約として、[eslint-config-universe](https://github.com/expo/expo/tree/master/packages/eslint-config-universe)を設定してあります。
-  * TypeScriptの型に関する規約([@typescript-eslint/recommended-requiring-type-checking](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules))も設定してあります。
-    * TypeScriptに慣れていないと、この規約が厳しく感じるかもしれません。実際にコードを書いてみて、対応するのが難しい指摘や効果の薄い指摘は個別にルールを無効化してみてください。
-  * 設定を変更したい場合は、ESLintやeslint-config-universeのドキュメントを確認して、`.eslintrc.js`を変更してください。
-* [EditorConfig](https://editorconfig.org/)
-  * 一般的と考えている設定をしています。内容については`.eslintconfig`内のコメントを確認してください。
-* [Prettier](https://prettier.io/)
-  * `npx react-native init`で生成されるものと同じ設定をしています。内容については`.prettierrc.js`内のコメントを確認してください。
-  * EditorConfigの設定も読み込むので、重複する内容を設定する必要はありません。[読み込まれるEditorConfigの設定値](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options)は次のものです。
-    * `end_of_line`
-    * `indent_style`
-    * `indent_size`, `tab_width`
-    * `max_line_length`
+- [ESLint](https://eslint.org/)
+  - 標準的な規約として、[eslint-config-universe](https://github.com/expo/expo/tree/master/packages/eslint-config-universe)を設定してあります。
+  - TypeScript の型に関する規約([@typescript-eslint/recommended-requiring-type-checking](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules))も設定してあります。
+    - TypeScript に慣れていないと、この規約が厳しく感じるかもしれません。実際にコードを書いてみて、対応するのが難しい指摘や効果の薄い指摘は個別にルールを無効化してみてください。
+  - 設定を変更したい場合は、ESLint や eslint-config-universe のドキュメントを確認して、`.eslintrc.js`を変更してください。
+- [EditorConfig](https://editorconfig.org/)
+  - 一般的と考えている設定をしています。内容については`.eslintconfig`内のコメントを確認してください。
+- [Prettier](https://prettier.io/)
+  - `npx react-native init`で生成されるものと同じ設定をしています。内容については`.prettierrc.js`内のコメントを確認してください。
+  - EditorConfig の設定も読み込むので、重複する内容を設定する必要はありません。[読み込まれる EditorConfig の設定値](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options)は次のものです。
+    - `end_of_line`
+    - `indent_style`
+    - `indent_size`, `tab_width`
+    - `max_line_length`
 
-ESLintでのチェックを実行するには、次のコマンドを実行してください。
+ESLint でのチェックを実行するには、次のコマンドを実行してください。
 
 ```bash
 npm run -s lint:es
@@ -86,11 +86,11 @@ npm run -s fix:es
 
 #### TypeScript
 
-[TypeScript](https://www.typescriptlang.org/)のコンパイラには、コーディング規約をチェックする機能があります。たとえば、型情報が適切に設定されているかどうかや、import/exportの構文が規約どおりになっているかなどをチェックすることができます。
+[TypeScript](https://www.typescriptlang.org/)のコンパイラには、コーディング規約をチェックする機能があります。たとえば、型情報が適切に設定されているかどうかや、import/export の構文が規約どおりになっているかなどをチェックすることができます。
 
 テンプレートでは、React Native (Expo) での標準的な内容を設定してあります。設定値の詳細については、`tsconfig.json`と[TSConfig Reference](https://www.typescriptlang.org/tsconfig)を参照してください。
 
-TypeScriptコンパイラでの規約チェックを実行するには、次のコマンドを実行してください。
+TypeScript コンパイラでの規約チェックを実行するには、次のコマンドを実行してください。
 
 ```bash
 npm run -s lint:tsc
@@ -98,5 +98,5 @@ npm run -s lint:tsc
 
 ## `expo-template-bare-typescript` からの変更点
 
-* [x] Editorconfig, ESLint, Prettierを追加
-* [x] TypeScriptの設定ファイルを修正、`tsc`での型チェックをlintに追加
+- [x] Editorconfig, ESLint, Prettier を追加
+- [x] TypeScript の設定ファイルを修正、`tsc`での型チェックを lint に追加

--- a/app.json
+++ b/app.json
@@ -5,8 +5,6 @@
     "name": "HelloWorld",
     "slug": "HelloWorld",
     "version": "1.0.0",
-    "assetBundlePatterns": [
-      "**/*"
-    ]
+    "assetBundlePatterns": ["**/*"]
   }
 }

--- a/gitignore
+++ b/gitignore
@@ -61,3 +61,6 @@ buck-out/
 # Expo
 .expo/*
 web-build/
+
+# Jest
+junit.xml

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -565,18 +565,18 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  EXConstants: 6ec1ea4a13ec734c7e2274bc9e5b7408d73007a1
-  EXErrorRecovery: cfb65ec51567cf57a00b2720a2367ac009298319
-  EXFileSystem: efd6c0225f90c8b2c85131d578a09e13197e8b70
-  EXFont: 91111ccdce7c739ff51c5fcb484f2dd9a9a4ce45
-  EXImageLoader: 0b33400e65955c5510a09afc2f9bb369a81e1c6e
-  EXKeepAwake: 4502a0ed7b7c5135587004e6d118acf8cea055fc
-  EXLinearGradient: 54bec9b1b4940407fc498cab6a0c49c617c8cf54
-  EXLocation: 210d39a6e5d793f9721117a11c0b27dc523a3183
-  EXPermissions: 5797c6c72efb411b2bbf502cd5acd841e3ffeefa
-  EXSplashScreen: accde6b1aaa87f395d6c5e0542e23d5c09a549ab
-  EXSQLite: 246074ef810a3b5e41c0cf8cde141adccc3b0f6b
-  EXUpdates: 305ea4c81ed9e6f70274c1f5fe765d646d5dcbdc
+  EXConstants: f486f6b4a36b86e47ab258d4d2b7b2699786fdce
+  EXErrorRecovery: 16696fe023fb46a32c3b09033abc361cfcf150a7
+  EXFileSystem: afe9b1fd937d30270bf5108ba44e2f4a1d1ad694
+  EXFont: a6a4353271395f3bb4ee528b52a5035b4b0e412a
+  EXImageLoader: 7153fb1307ac643299a9072b71da0d276f4c7789
+  EXKeepAwake: 76eed36786534f6a476748e600fa6faf07ac3d09
+  EXLinearGradient: c7ca1c2933ac240ffbc805c014a72947e227ac75
+  EXLocation: 90232c6f2773b04a3c146bfda9f181035722c10a
+  EXPermissions: 30cbe5b72bd209b65c00884180ad058a60bb413d
+  EXSplashScreen: 7ea40b8524f27e7444e3892411c8a4782ab6b4ce
+  EXSQLite: d0d8677c13e60d5db2812387f059c697be27d3fb
+  EXUpdates: 74b39409f68eca207075d87b0077bdf37865a8bf
   FBLazyVector: 878b59e31113e289e275165efbe4b54fa614d43d
   FBReactNativeSpec: 7da9338acfb98d4ef9e5536805a0704572d33c2f
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
@@ -612,19 +612,19 @@ SPEC CHECKSUMS:
   RNGestureHandler: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
   RNReanimated: dd8c286ab5dd4ba36d3a7fef8bff7e08711b5476
   RNScreens: b748efec66e095134c7166ca333b628cd7e6f3e2
-  UMAppLoader: 939854a42e69527ee11dd17b39ebafcbfbefd05c
-  UMBarCodeScannerInterface: 198ced513a0cf8143d822620f1620bce467d02be
-  UMCameraInterface: dbcaade8d0364ba5518ae4519c63c59bf010aa89
-  UMConstantsInterface: 2ad180a29afdf28607d11d6e23c90793d294ea0e
-  UMCore: 9b6c0ae27349356ed39c9e78b99b7830bb093856
-  UMFaceDetectorInterface: 24faf81d90fb00d477c674fd00b9cb005176f4a0
-  UMFileSystemInterface: 5216dca58177014de7f1157d69c70a1ec5c620bb
-  UMFontInterface: 4d0f13001fc59436125d7424cdfa7c897b699724
-  UMImageLoaderInterface: 575357942cc57ad31662659df9d5a73daa6de54c
-  UMPermissionsInterface: 208b2c5fd6756dcad739d806dfe32b9e44b9311b
-  UMReactNativeAdapter: 2c175f151cfe5ff011ced7bc79ccb08bf124f6c3
-  UMSensorsInterface: 1df848f22690ccd23a821777f00df230fe5a28e3
-  UMTaskManagerInterface: dfc62edf51844ae87dafc1fe849b594871fda1e5
+  UMAppLoader: 5db5dc03176c6238da9c8b3657a370137882a4ad
+  UMBarCodeScannerInterface: 017672479f93de88d94c3a50dfb66b5348b65989
+  UMCameraInterface: 22bd2c4bf15dcf68530368fa5704af7490818457
+  UMConstantsInterface: ff612789417aace6fd01a9c35616bc87dcdc8d97
+  UMCore: 94e4725ab2efbbe247b5910a2a954a2dab64f7eb
+  UMFaceDetectorInterface: 9bc6a197ad9d4d16ba13bfdf2340dd7f24964308
+  UMFileSystemInterface: e7795274eee76beaadaf6015bcc7f5da3054b925
+  UMFontInterface: bc5dd878b2f6fffdac80e41fd36893c619683712
+  UMImageLoaderInterface: 78ab0fd45c2bcaee61957fa23858bf31f2bcb122
+  UMPermissionsInterface: 4f21b0c2aaf953cf041109ff44231b2a69e22836
+  UMReactNativeAdapter: 61ae88818058b7849bbf5b79bf97872cb3c8e0eb
+  UMSensorsInterface: 49bea41dcfcc041f0bbab27cfe4a6006f1dde0c0
+  UMTaskManagerInterface: 6cad5929dbc0a5b986ad4d77caac497d4de730a7
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9855,6 +9855,26 @@
         }
       }
     },
+    "jest-junit": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.0.0.tgz",
+      "integrity": "sha512-+8K35LlboWiPuCnXSyiid7rFdxNlpCWWM20WEYe6IZH6psfUWKZmSpSRQ5tk0C0cBeDsvsnIzcef5mYhyJsbug==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^5.2.0",
+        "uuid": "^3.3.3",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
@@ -11841,6 +11861,12 @@
         "buffer-alloc": "^1.1.0"
       }
     },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -12791,6 +12817,69 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -13246,6 +13335,12 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
     "pify": {
@@ -15144,6 +15239,37 @@
         }
       }
     },
+    "string.prototype.padend": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
@@ -16181,6 +16307,12 @@
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-js": {
       "version": "1.6.11",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
     "web": "expo start --web",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint --ext .jsx,.js,.tsx,.ts .",
-    "lint:fix": "eslint --fix --ext .jsx,.js,.tsx,.ts ."
+    "lint": "run-s --print-name --continue-on-error lint:*",
+    "lint:es": "eslint --ext .jsx,.js,.tsx,.ts .",
+    "lint:tsc": "tsc --noEmit",
+    "fix": "run-s --print-name --continue-on-error fix:*",
+    "fix:es": "eslint --fix --ext .jsx,.js,.tsx,.ts ."
   },
   "dependencies": {
     "expo": "~39.0.2",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,18 @@
     "eslint": "^7.10.0",
     "eslint-config-universe": "^5.0.0",
     "jest-expo": "~39.0.0",
+    "jest-junit": "^12.0.0",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
     "typescript": "~3.9.5"
   },
   "jest": {
     "preset": "react-native"
+  },
+  "jest-junit": {
+    "suiteNameTemplate": "{filepath}",
+    "classNameTemplate": "{classname}",
+    "titleTemplate": "{title}"
   },
   "private": true
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,66 @@
+// TSConfig Reference: https://www.typescriptlang.org/tsconfig
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "jsx": "react-native",
-    "lib": ["dom", "esnext"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "strict": true
-  }
+    /* Basic Options */
+    "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": ["dom", "esnext"],                 /* Specify library files to be included in the compilation. */
+    "allowJs": true,                          /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react-native",                    /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    "noEmit": true,                           /* Do not emit outputs. */
+    // "incremental": true,                   /* Enable incremental compilation */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    "isolatedModules": true,                  /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced */
+    "resolveJsonModule": true,                /* Allows importing modules with a ‘.json’ extension, which is a common practice in node projects. This includes generating a type for the import based on the static JSON shape. */
+    "skipLibCheck": true                      /* Skip type checking of declaration files. */
+  },
+  "exclude": [
+    "node_modules", "babel.config.js", "metro.config.js", "jest.config.js", ".prettierrc.js", ".eslintrc.js"
+  ]
 }


### PR DESCRIPTION
## 💣 BREAKING CHANGE 💣

- [x] Change npm script name to run lints

## やったこと

- [x] Add npm script to run tsc as lint
- [x] Improve documentation
- [x] Add TypeScript lint and tests to GitHub Actions workflow

## やっていないこと

Nothing, maybe.

## 動作確認

- [x] `npm run lint`, `npm run lint:es`, `npm run lint:tsc`
- [x] `npm run fix`, `npm run fix:es`
- [x] Local execution of commands used in GitHub Actions (except for `reviewdog`).
  - [x] `npm clean-install`
  - [x] `npm run -s lint:es`
  - [x] `npm run -s lint:tsc`
  - [x] `npm run -s test -- --ci --reporters=default --reporters=jest-junit`

## デバイス

It's not about the devices.

## その他（レビュアーへの申し送り事項、懸念点など）

I can't think of anything.
