### PR TITLE
🐛: Triage workflow is not triggered when a pull request is opened...

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -3,7 +3,7 @@ name: Triage
 on:
   pull_request:
     types:
-      - opend
+      - opened
       - edited
       - reopened
 


### PR DESCRIPTION
## やったこと

- [x] Fix type (`opend` -> `opened`)
- [x] Search `opend` in this repository (Not found any other)

## やっていないこと

Nothing

## 動作確認

- [x] Triage workflow is triggered when this pull request is opened

## デバイス

It's not about the devices

## その他（レビュアーへの申し送り事項、懸念点など）

None