### PR TITLE
📈: Do not run auto-complete action just after the pr is 'ready-for-review'

### DIFF
--- a/.github/workflows/auto-complete.yaml
+++ b/.github/workflows/auto-complete.yaml
@@ -6,7 +6,6 @@ on:
       - labeled
       - unlabeled
       - synchronize
-      - ready_for_review
       - reopened
   pull_request_review:
     types:


### PR DESCRIPTION
## やったこと

- [x] Remove `ready_for_review` from triggers of auto-complete action

## やっていないこと

Nothing

## 動作確認

- [x] Auto-complete action does not triggered after this pull request becomes ready for review

## デバイス

It's nothing about the devices.

## その他（レビュアーへの申し送り事項、懸念点など）

None