### PR TITLE
🐛: Increase memory size for Gradle build, cache gradle build caches in GitHub Actions

### DIFF
--- a/.github/workflows/auto-complete.yaml
+++ b/.github/workflows/auto-complete.yaml
@@ -18,6 +18,8 @@ jobs:
   auto-complete:
     runs-on: ubuntu-latest
     # Auto-complete takes too much time, so run it only when pr is not a draft
+    # Auto-complete merges if there is a check failure and 'mergeable_state' is 'unstable'
+    # cf: https://github.com/pascalgn/automerge-action/issues/90
     if: ${{ github.event.pull_request.draft == false && github.event.pull_request.mergeable_state != 'unstable' }}
     env:
       GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/auto-complete.yaml
+++ b/.github/workflows/auto-complete.yaml
@@ -18,7 +18,7 @@ jobs:
   auto-complete:
     runs-on: ubuntu-latest
     # Auto-complete takes too much time, so run it only when pr is not a draft
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.mergeable_state != 'unstable' }}
     env:
       GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
     steps:

--- a/.github/workflows/auto-complete.yaml
+++ b/.github/workflows/auto-complete.yaml
@@ -5,8 +5,6 @@ on:
     types:
       - labeled
       - unlabeled
-      - synchronize
-      - reopened
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -99,6 +99,17 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm clean-install
 
+      # Cache '.gradle' to speed up gradle build
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          # If cache is corrupted, increment prefixed number.
+          key: 1-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            1-${{ runner.os }}-gradle-
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -100,7 +100,8 @@ jobs:
         run: npm clean-install
 
       # Cache '.gradle' to speed up gradle build
-      - uses: actions/cache@v2
+      - name: Cache .gradle
+        uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx10248m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx10248m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx512m -XX:MaxPermSize=128m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx128m -XX:MaxPermSize=64m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx10248m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx512m -XX:MaxPermSize=128m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx128m -XX:MaxPermSize=64m -XX:+HeapDumpOnOutOfMemoryError
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/docs/content/react-native/troubleshooting/_index.md
+++ b/docs/content/react-native/troubleshooting/_index.md
@@ -8,12 +8,43 @@ title: Troubleshooting
 
 たいていの場合はどこかにタイポがあったりして「あぁ、ミスってた〜」となるのですが、本当にどうにも原因がわからないこともあります。
 
-そういった場合にビルドなどのキャッシュをクリアすると何故かうまく動いてしまうこともあるので、このテンプレートではReact Nativeで開発しているときに生成されるキャッシュなどをすべて削除するスクリプトを用意しています。
+そういった場合にビルドなどのキャッシュをクリアすると何故かうまく動いてしまうこともあるので、このテンプレートでは React Native で開発しているときに生成されるキャッシュなどをすべて削除するスクリプトを用意しています。
 
 次のコマンドを実行することで、ビルド時に利用されているキャッシュをすべて削除することが出来ます。なお、このコマンドを実行するとすべてのキャッシュが削除されるため、次回のアプリケーションビルドにかなり時間がかかるようになります。
 
-> **Note**: コマンドを実行する前に、Metroサーバを停止してください。また、Android StudioやXcodeなども終了しおくことをおすすめします。
+> **Note**: コマンドを実行する前に、Metro サーバを停止してください。また、Android Studio や Xcode なども終了しおくことをおすすめします。
 
 ```
 npm run reset-cache
 ```
+
+## Android アプリのビルドで OutOfMemoryError
+
+Android アプリのビルドで OutOfMemoryError が発生したときは、Gradleが立ち上げるJVMのヒープサイズを増やして対応してください。
+
+`android/gradle.properties` の `org.gradle.jvmargsorg.gradle.jvmargs` で設定する `Xmx` や `XX:MaxPermSize` の値を増やすことで解決できるはずです。
+
+
+## 【未解決】 createReleaseExpoManifest でエラーが発生してしまう
+
+Android アプリのビルドの際に、 `:app:createReleaseExpoManifest` で次のようなエラーが発生することがあります。
+
+```
+> Task :app:createReleaseExpoManifest FAILED
+internal/modules/cjs/loader.js:968
+  throw err;
+  ^
+
+Error: Cannot find module '/scripts/createManifest.js'
+    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:965:15)
+    at Function.Module._load (internal/modules/cjs/loader.js:841:27)
+    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
+    at internal/main/run_main_module.js:17:47 {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: []
+}
+```
+
+以下のようなIssueが挙げられているのですが、2020-10-16時点ではまだ解決方法は回答されていません。
+* https://github.com/expo/expo/issues/8547
+* https://github.com/expo/expo-cli/issues/2232


### PR DESCRIPTION
## やったこと

- [x] Increase `Xmx` and `XX:MaxPermSize` in `android/gradle.properties`
- [x] Skip auto-complete action if checks are failing
- [x] Not run auto-complete after pull requests are 'synchronized'

## やっていないこと

None

## 動作確認

- [x] Reproduce OOM
  - Not reproduced but I have confirmed that options are working.
- [x] Increase memory size and check if error not occurs
- [x] Auto-merge action is skipped if there are check failures

## デバイス

It's not about the devices.

## その他（レビュアーへの申し送り事項、懸念点など）

I can't think about anything.