### PR TITLE
🌱: Add React Navigation examples (simple tab and stack navigators)

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -47,4 +47,5 @@ doc:
 test:
   - __tests__/**/*
   - __mocks__/**/*
+  - __setup__/**/*
   - jest.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build/
 .gradle
 local.properties
 *.iml
+android/*.hprof
 
 # node.js
 #

--- a/__mocks__/react-native-screens.js
+++ b/__mocks__/react-native-screens.js
@@ -1,0 +1,15 @@
+const View = require('react-native').View;
+
+export const enableScreens = jest.fn();
+export const screensEnabled = jest.fn(() => true);
+export const ScreenContainer = View;
+export const Screen = View;
+export const NativeScreen = View;
+export const NativeScreenContainer = View;
+export const ScreenStack = View;
+export const ScreenStackHeaderConfig = View;
+export const ScreenStackHeaderSubview = View;
+export const ScreenStackHeaderRightView = View;
+export const ScreenStackHeaderLeftView = View;
+export const ScreenStackHeaderTitleView = View;
+export const ScreenStackHeaderCenterView = View;

--- a/__setup__/react-navigation.js
+++ b/__setup__/react-navigation.js
@@ -1,0 +1,19 @@
+// https://reactnavigation.org/docs/testing#mocking-native-modules
+// > To be able to test React Navigation components, we need to mock the following dependencies including native code:
+// >   * react-native-reanimated
+// >   * react-native-gesture-handler
+
+import 'react-native-gesture-handler/jestSetup';
+
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+
+  // The mock for `call` immediately calls the callback which is incorrect
+  // So we override it with a no-op
+  Reanimated.default.call = () => {};
+
+  return Reanimated;
+});
+
+// Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
+jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');

--- a/__tests__/App.js
+++ b/__tests__/App.js
@@ -4,6 +4,9 @@ import renderer from 'react-test-renderer';
 
 import App from '../src/App.tsx';
 
+// https://github.com/facebook/jest/issues/6434#issuecomment-525576660
+jest.useFakeTimers();
+
 // Note: test renderer must be required after react-native.
 
 it('renders correctly', () => {

--- a/__tests__/App.js
+++ b/__tests__/App.js
@@ -1,14 +1,12 @@
 import 'react-native';
 import React from 'react';
-import renderer from 'react-test-renderer';
+// Note: test renderer must be required after react-native.
+import {act, create} from 'react-test-renderer';
 
 import App from '../src/App.tsx';
 
-// https://github.com/facebook/jest/issues/6434#issuecomment-525576660
-jest.useFakeTimers();
-
-// Note: test renderer must be required after react-native.
-
-it('renders correctly', () => {
-  renderer.create(<App />);
+it('renders correctly', async () => {
+  await act(async () => {
+    create(<App />);
+  });
 });

--- a/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -13,7 +13,10 @@ import expo.modules.splashscreen.SplashScreenImageResizeMode;
 public class MainActivity extends ReactActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    // https://github.com/software-mansion/react-native-screens#android
+    // https://github.com/software-mansion/react-native-screens/issues/17
+    // Discard any Activity state persisted during the Activity restart process, to avoid inconsistencies that lead to crashes.
+    super.onCreate(null);
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     // Below line is handled by '@expo/configure-splash-screen' command and it's discouraged to modify it manually
     SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class, false);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
+import 'react-native-gesture-handler';
 import {registerRootComponent} from 'expo';
+import {enableScreens} from 'react-native-screens';
 
 import App from './src/App';
+
+// https://reactnavigation.org/docs/react-native-screens
+// Enable screens support before rendering any of navigation stack
+enableScreens();
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in the Expo client or in a native build,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -273,6 +273,8 @@ PODS:
   - React-jsinspector (0.63.3)
   - react-native-appearance (0.3.4):
     - React
+  - react-native-safe-area-context (3.1.4):
+    - React
   - React-RCTActionSheet (0.63.3):
     - React-Core/RCTActionSheetHeaders (= 0.63.3)
   - React-RCTAnimation (0.63.3):
@@ -333,6 +335,8 @@ PODS:
     - React-Core (= 0.63.3)
     - React-cxxreact (= 0.63.3)
     - React-jsi (= 0.63.3)
+  - RNCMaskedView (0.1.10):
+    - React
   - RNGestureHandler (1.7.0):
     - React
   - RNReanimated (1.13.1):
@@ -412,6 +416,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-appearance (from `../node_modules/react-native-appearance`)
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -422,6 +427,7 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -513,6 +519,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-appearance:
     :path: "../node_modules/react-native-appearance"
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -533,6 +541,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/Vibration"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCMaskedView:
+    :path: "../node_modules/@react-native-community/masked-view"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -610,6 +620,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
   react-native-appearance: 0f0e5fc2fcef70e03d48c8fe6b00b9158c2ba8aa
+  react-native-safe-area-context: eb91fe1fb3f7b87d9c30a7f0808407d8569d539d
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40
@@ -620,6 +631,7 @@ SPEC CHECKSUMS:
   React-RCTText: 65a6de06a7389098ce24340d1d3556015c38f746
   React-RCTVibration: 8e9fb25724a0805107fc1acc9075e26f814df454
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
+  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
   RNReanimated: dd8c286ab5dd4ba36d3a7fef8bff7e08711b5476
   RNScreens: b748efec66e095134c7166ca333b628cd7e6f3e2

--- a/package-lock.json
+++ b/package-lock.json
@@ -4060,6 +4060,75 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-4.10.1.tgz",
       "integrity": "sha512-ael2f1onoPF3vF7YqHGWy7NnafzGu+yp88BbFbP0ydoCP2xGSUzmZVw0zakPTC040Id+JQ9WeFczujMkDy6jYQ=="
     },
+    "@react-native-community/masked-view": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.10.tgz",
+      "integrity": "sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ=="
+    },
+    "@react-navigation/bottom-tabs": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-5.9.2.tgz",
+      "integrity": "sha512-nSaAXFNbRukhMGq4U3m1rqbFZEPT64/gPTwUwQ5YQom5Q0a6xZ0AnOmtFIXvDBbK5VJiokGdBLJ/TMDchqcujQ==",
+      "requires": {
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.2.1"
+      }
+    },
+    "@react-navigation/core": {
+      "version": "5.12.5",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.5.tgz",
+      "integrity": "sha512-+QdQDtC75K1sBfACwCUNFlrCOYf36GYGr9YURHugm3LDEHUwAj7HPJA8FFLw1Rmp5N/P5q9Uct2B/XxJhYzKqA==",
+      "requires": {
+        "@react-navigation/routers": "^5.4.12",
+        "escape-string-regexp": "^4.0.0",
+        "nanoid": "^3.1.12",
+        "query-string": "^6.13.5",
+        "react-is": "^16.13.0",
+        "use-subscription": "^1.4.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
+    "@react-navigation/drawer": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-5.9.3.tgz",
+      "integrity": "sha512-bc9cyJGONvTf6tsdwjgyMV5VMVIgJc9URMGbiXzj68Vp94lsxi6YbsOW01ErLpD8ltyCBNEC+Ll/1vv6CZiJaQ==",
+      "requires": {
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.2.1"
+      }
+    },
+    "@react-navigation/native": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.7.6.tgz",
+      "integrity": "sha512-u+o9Ifs4//Ah6UczXiaAV+hiWPL0NyTbErj5WayeQUd6K5IIbA1UwumRVWs2Xp8q/4Q9h6FpPHUcKOyiTxhaqA==",
+      "requires": {
+        "@react-navigation/core": "^5.12.5",
+        "nanoid": "^3.1.12"
+      }
+    },
+    "@react-navigation/routers": {
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.4.12.tgz",
+      "integrity": "sha512-IwMmxeb5e6LboljhakmhtrHBXLYFrFDr2c1GjAG538e4MjT4QGi/ZYckAxCh/NqKI0knnzqKppPl2NsOMv/NoQ==",
+      "requires": {
+        "nanoid": "^3.1.12"
+      }
+    },
+    "@react-navigation/stack": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-5.9.3.tgz",
+      "integrity": "sha512-/CJ5Rsrc9bMI20dD8oC/QSZHARMFuUv8DeoiYE7R2N0M44cFupF1CrzaZBBC/S4Zi1ahZ0A+Hj/gAzAEQrNTvA==",
+      "requires": {
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.2.1"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -12763,6 +12832,11 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -13688,6 +13762,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
+    "query-string": {
+      "version": "6.13.6",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.6.tgz",
+      "integrity": "sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -14227,6 +14311,11 @@
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2"
       }
+    },
+    "react-native-iphone-x-helper": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.0.tgz",
+      "integrity": "sha512-+/bcZWFeZt0xSS/+3CHM5K7qPL4vDO/3ARLIowzFpUPGZiPsv9+NET+XNqqseRYwFJwYMmtX+Q4TZKxAVy09ew=="
     },
     "react-native-ratings": {
       "version": "7.3.0",
@@ -15231,6 +15320,11 @@
       "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15315,6 +15409,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ios": "react-native run-ios",
     "web": "expo start --web",
     "start": "react-native start",
-    "test": "jest",
+    "test": "jest --detectOpenHandles",
     "lint": "run-s --print-name --continue-on-error lint:*",
     "lint:es": "eslint --ext .jsx,.js,.tsx,.ts .",
     "lint:tsc": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "reset-cache": "node .script/runner.js reset-cache"
   },
   "dependencies": {
+    "@react-native-community/masked-view": "0.1.10",
+    "@react-navigation/bottom-tabs": "^5.9.2",
+    "@react-navigation/drawer": "^5.9.3",
+    "@react-navigation/native": "^5.7.6",
+    "@react-navigation/stack": "^5.9.3",
     "expo": "~39.0.2",
     "expo-splash-screen": "~0.6.2",
     "expo-updates": "~0.3.3",
@@ -25,6 +30,7 @@
     "react-native-gesture-handler": "~1.7.0",
     "react-native-reanimated": "~1.13.0",
     "react-native-responsive-screen": "~1.4.1",
+    "react-native-safe-area-context": "3.1.4",
     "react-native-screens": "~2.10.1",
     "react-native-unimodules": "~0.11.0",
     "react-native-vector-icons": "~7.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
     "typescript": "~3.9.5"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "jest-expo",
+    "setupFiles": [
+      "<rootDir>/__setup__/react-navigation.js"
+    ]
   },
   "jest-junit": {
     "suiteNameTemplate": "{filepath}",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,12 +30,3 @@ export default function App() {
     </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,27 @@
+import {NavigationContainer} from '@react-navigation/native';
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+// StackNavigatorには、ネイティブUIでスクリーンを表示するNativeStackNavigatorを利用します。
+// ただし、あまりカスタマイズ出来ないようなので、もし細かいカスタマイズが必要になった場合はドキュメントに記載してる通りデフォルトのStackNavigatorを利用するように変更してください。
+// https://reactnavigation.org/docs/react-native-screens/
+// https://reactnavigation.org/docs/native-stack-navigator/
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+
+import {MainNavigator} from './components/MainNavigator';
+import {ExampleNavigator} from './example/components/ExampleDrawer';
+
+// モーダル画面などを表示するために、アプリが主として利用するTabNavigatorの前にStackNavigatorを用意しておきます。
+// https://reactnavigation.org/docs/modal/
+const RootStack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-    </View>
+    <NavigationContainer>
+      {/* テンプレートに含まれるサンプルをアプリ内で表示できるように、DrawerNavigatorを用意しています。*/}
+      {/* 必要なくなったらScreenを削除し、initialRouteNameをExampleからMainに変更してください。 */}
+      <RootStack.Navigator screenOptions={{headerShown: false}} initialRouteName="Example">
+        <RootStack.Screen name="Main" component={MainNavigator} />
+        <RootStack.Screen name="Example" component={ExampleNavigator} options={{gestureEnabled: false}} />
+      </RootStack.Navigator>
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import 'react-native-gesture-handler';
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 

--- a/src/components/MainNavigator.tsx
+++ b/src/components/MainNavigator.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {createNativeStackNavigator} from 'react-native-screens/native-stack';
+
+import HelloWorld from './pages/HelloWorld';
+
+// テンプレートでは、スタックを利用しています。
+// アプリでタブの利用する場合は、ここをcreateBottomTabNavigatorに変更してください。
+const Main = createNativeStackNavigator();
+
+export function MainNavigator() {
+  return (
+    <Main.Navigator initialRouteName={HelloWorld.name}>
+      <Main.Screen name={HelloWorld.name} component={HelloWorld.component} options={HelloWorld.options} />
+    </Main.Navigator>
+  );
+}

--- a/src/components/pages/HelloWorld.tsx
+++ b/src/components/pages/HelloWorld.tsx
@@ -1,0 +1,93 @@
+import React, {useContext, useMemo} from 'react';
+import {Dimensions, StyleSheet, View} from 'react-native';
+import {Text, ThemeContext} from 'react-native-elements';
+import Animated, {Easing, Value, timing, Clock, block, startClock, cond, set, useCode, not, clockRunning, eq} from 'react-native-reanimated';
+import FontAwesome5Icon from 'react-native-vector-icons/FontAwesome5';
+
+const screenWidth = Dimensions.get('window').width;
+const progress = (clock: Clock, from: number, to: number) => {
+  const progress = {
+    finished: new Value(0),
+    position: new Value(from),
+    time: new Value(0),
+    frameTime: new Value(0),
+  };
+  const config = {
+    duration: 2000,
+    toValue: to,
+    easing: Easing.inOut(Easing.ease),
+  };
+
+  return block([
+    // we run the step here that is going to update position
+    cond(not(clockRunning(clock)), set(progress.time, 0), timing(clock, progress, config)),
+    cond(eq(progress.finished, 1), [set(progress.finished, 0), set(progress.position, from), set(progress.frameTime, 0), set(progress.time, 0)]),
+    progress.position,
+  ]);
+};
+
+const Arrow = () => {
+  const from = (-screenWidth / 2) * 0.85;
+  const to = (screenWidth / 2) * 0.4;
+  const {x, opacity, clock} = useMemo(
+    () => ({
+      x: new Value(from),
+      opacity: new Value(1),
+      clock: new Clock(),
+    }),
+    [],
+  );
+
+  useCode(() => block([cond(not(clockRunning(clock)), startClock(clock)), set(x, progress(clock, from, to)), set(opacity, progress(clock, 1, 0))]), [
+    x,
+    clock,
+  ]);
+
+  return (
+    <Animated.View style={{transform: [{translateX: x}], opacity, flex: 1, justifyContent: 'center'}}>
+      <FontAwesome5Icon name="angle-right" style={StyleSheet.flatten([styles.textColor, styles.arrowStyle])} />
+    </Animated.View>
+  );
+};
+
+const HelloWorld = () => {
+  const {theme} = useContext(ThemeContext);
+  return (
+    <View style={StyleSheet.flatten([StyleSheet.absoluteFillObject, styles.container, {backgroundColor: theme.colors?.primary}])}>
+      <Arrow />
+      <Text h1 style={styles.textColor}>
+        Hello, World!
+      </Text>
+      <View style={styles.caption}>
+        <Text style={StyleSheet.flatten([styles.textColor, styles.captionText])}>Swipe right to show menu</Text>
+      </View>
+      <Arrow />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  caption: {
+    marginVertical: 20,
+  },
+  captionText: {
+    fontSize: 30,
+  },
+  textColor: {
+    color: '#fefefe',
+  },
+  arrowStyle: {
+    fontSize: 100,
+  },
+});
+
+export default {
+  name: 'Hello World',
+  component: HelloWorld,
+  options: {headerShown: false},
+};

--- a/src/example/components/ExampleDrawer.tsx
+++ b/src/example/components/ExampleDrawer.tsx
@@ -1,0 +1,16 @@
+import {createDrawerNavigator} from '@react-navigation/drawer';
+import React from 'react';
+
+import {MainNavigator} from '../../components/MainNavigator';
+import {MainNavigator as ExampleMainNavigator} from './MainNavigator';
+
+const ExampleDrawer = createDrawerNavigator();
+
+export function ExampleNavigator() {
+  return (
+    <ExampleDrawer.Navigator initialRouteName="MainNavigator">
+      <ExampleDrawer.Screen name="HelloWorld" component={MainNavigator} />
+      <ExampleDrawer.Screen name="Example" component={ExampleMainNavigator} options={{swipeEnabled: false}} />
+    </ExampleDrawer.Navigator>
+  );
+}

--- a/src/example/components/MainNavigator.tsx
+++ b/src/example/components/MainNavigator.tsx
@@ -1,0 +1,24 @@
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import React from 'react';
+
+import HomeScreen from './pages/HomeScreen';
+import SettingsScreen from './pages/SettingsScreen';
+import FormWizardNavigator from './pages/form/FormWizardNavigator';
+
+const Main = createBottomTabNavigator();
+
+export type AppRouteProps = {
+  Home: undefined;
+  Settings: undefined;
+  Form: undefined;
+};
+
+export function MainNavigator() {
+  return (
+    <Main.Navigator initialRouteName={HomeScreen.name}>
+      <Main.Screen name={HomeScreen.name} component={HomeScreen.component} options={HomeScreen.options} />
+      <Main.Screen name={FormWizardNavigator.name} component={FormWizardNavigator.component} options={FormWizardNavigator.options} />
+      <Main.Screen name={SettingsScreen.name} component={SettingsScreen.component} options={SettingsScreen.options} />
+    </Main.Navigator>
+  );
+}

--- a/src/example/components/pages/HomeScreen.tsx
+++ b/src/example/components/pages/HomeScreen.tsx
@@ -1,0 +1,20 @@
+import {BottomTabNavigationOptions} from '@react-navigation/bottom-tabs';
+import React from 'react';
+import {Text} from 'react-native-elements';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
+export default {
+  name: 'Home',
+  component: Component,
+  options: {
+    tabBarIcon: () => <Text>🏠</Text>,
+  } as BottomTabNavigationOptions,
+};
+
+function Component() {
+  return (
+    <SafeAreaView>
+      <Text>Home Component</Text>
+    </SafeAreaView>
+  );
+}

--- a/src/example/components/pages/SettingsScreen.tsx
+++ b/src/example/components/pages/SettingsScreen.tsx
@@ -1,0 +1,20 @@
+import {BottomTabNavigationOptions} from '@react-navigation/bottom-tabs';
+import React from 'react';
+import {Text} from 'react-native-elements';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
+export default {
+  name: 'Settings',
+  component: Component,
+  options: {
+    tabBarIcon: () => <Text>⚙️</Text>,
+  } as BottomTabNavigationOptions,
+};
+
+function Component() {
+  return (
+    <SafeAreaView>
+      <Text>Settings Component</Text>
+    </SafeAreaView>
+  );
+}

--- a/src/example/components/pages/form/FormWizardNavigator.tsx
+++ b/src/example/components/pages/form/FormWizardNavigator.tsx
@@ -1,0 +1,52 @@
+import {RouteProp} from '@react-navigation/native';
+import React from 'react';
+import {Text} from 'react-native-elements';
+import {createNativeStackNavigator, NativeStackNavigationProp} from 'react-native-screens/native-stack';
+
+import {AppRouteProps} from '../../MainNavigator';
+import InputForm1Screen from './InputForm1Screen';
+import InputForm2Screen from './InputForm2Screen';
+import InputFormCompleteScreen from './InputFormCompleteScreen';
+import InputFormConfirmScreen from './InputFormConfirmScreen';
+
+// このウィザードで利用する画面と、それらの画面が受け取るパラメータの一覧です。
+export type FormWizardParams = {
+  Input1: undefined;
+  Input2: undefined;
+  Confirm: undefined;
+  Complete: undefined;
+};
+
+// このウィザードで利用する画面がComponentのPropsとして受け取る値の型です。
+export type FormWizardScreenProps<T extends keyof FormWizardParams> = {
+  route: RouteProp<FormWizardParams, T>;
+  navigation: NativeStackNavigationProp<FormWizardParams, T> & NativeStackNavigationProp<AppRouteProps, keyof AppRouteProps>;
+};
+
+// ウィザード内でナビゲーションするためのスタックを定義します。
+const Stack = createNativeStackNavigator<FormWizardParams>();
+
+// デフォルトでは戻る先の画面名は表示しないようにしています。
+const defaultScreenOptions = {headerBackTitle: '', headerBackTitleVisible: false};
+
+// このウィザードで表示する画面の一覧を定義します。
+const screens = [InputForm1Screen, InputForm2Screen, InputFormConfirmScreen, InputFormCompleteScreen];
+
+// 画面をナビゲータに登録します。
+function Component() {
+  return (
+    <Stack.Navigator screenOptions={defaultScreenOptions}>
+      {screens.map((screen) => (
+        <Stack.Screen key={screen.name} {...screen} />
+      ))}
+    </Stack.Navigator>
+  );
+}
+
+export default {
+  name: 'Wizard',
+  component: Component,
+  options: {
+    tabBarIcon: () => <Text>🖋</Text>,
+  },
+};

--- a/src/example/components/pages/form/InputForm1Screen.tsx
+++ b/src/example/components/pages/form/InputForm1Screen.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Button, Text} from 'react-native-elements';
+
+import {WizardScreenDefinition} from '../../parts/WizardScreenDefinition';
+import {FormWizardParams, FormWizardScreenProps} from './FormWizardNavigator';
+
+// この画面をどのようにNavigatorに登録するかを定義します。
+const Definition: WizardScreenDefinition<FormWizardParams> = {
+  // この画面のナビゲーション内での名前です。navigation.navigate('Input1')のようにして、この画面に遷移してくることが出来ます。
+  name: 'Input1',
+  // この画面で表示するコンポーネントです。
+  component: Component,
+  // この画面を表示するときにNavigatorが利用するオプションです。
+  options: {
+    // タイトルはデフォルトでは`name`の値が利用されますが、ここでは少し変更しています。
+    headerTitle: '🖋 Input 1',
+  },
+};
+export default Definition;
+
+function Component({navigation}: FormWizardScreenProps<typeof Definition.name>) {
+  return (
+    <View>
+      <Text>Input Form 1 Component</Text>
+      <Button onPress={() => navigation.navigate('Input2')}>Next</Button>
+    </View>
+  );
+}

--- a/src/example/components/pages/form/InputForm2Screen.tsx
+++ b/src/example/components/pages/form/InputForm2Screen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Button, Text} from 'react-native-elements';
+
+import {WizardScreenDefinition} from '../../parts/WizardScreenDefinition';
+import {FormWizardParams, FormWizardScreenProps} from './FormWizardNavigator';
+
+const Definition: WizardScreenDefinition<FormWizardParams> = {
+  name: 'Input2',
+  component: Component,
+  options: {
+    headerTitle: '🖋 Input 2',
+  },
+};
+export default Definition;
+
+function Component({navigation}: FormWizardScreenProps<typeof Definition.name>) {
+  return (
+    <View>
+      <Text>Input Form 2 Component</Text>
+      <Button onPress={() => navigation.navigate('Confirm')}>Next</Button>
+    </View>
+  );
+}

--- a/src/example/components/pages/form/InputFormCompleteScreen.tsx
+++ b/src/example/components/pages/form/InputFormCompleteScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Button, Text} from 'react-native-elements';
+
+import {WizardScreenDefinition} from '../../parts/WizardScreenDefinition';
+import {FormWizardParams, FormWizardScreenProps} from './FormWizardNavigator';
+
+const Definition: WizardScreenDefinition<FormWizardParams> = {
+  name: 'Complete',
+  component: Component,
+  options: {
+    headerTitle: '✔️ Complete',
+    headerHideBackButton: true,
+  },
+};
+export default Definition;
+
+function Component({navigation}: FormWizardScreenProps<typeof Definition.name>) {
+  return (
+    <View>
+      <Text>Confirm Component</Text>
+      <Button onPress={() => navigation.navigate('Home')}>Back to Home</Button>
+    </View>
+  );
+}

--- a/src/example/components/pages/form/InputFormConfirmScreen.tsx
+++ b/src/example/components/pages/form/InputFormConfirmScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Button, Text} from 'react-native-elements';
+
+import {WizardScreenDefinition} from '../../parts/WizardScreenDefinition';
+import {FormWizardParams, FormWizardScreenProps} from './FormWizardNavigator';
+
+const Definition: WizardScreenDefinition<FormWizardParams> = {
+  name: 'Confirm',
+  component: Component,
+  options: {
+    headerTitle: '👀 Confirm',
+  },
+};
+export default Definition;
+
+function Component({navigation}: FormWizardScreenProps<typeof Definition.name>) {
+  return (
+    <View>
+      <Text>Confirm Component</Text>
+      <Button onPress={() => navigation.navigate('Complete')}>Next</Button>
+    </View>
+  );
+}

--- a/src/example/components/parts/WizardScreenDefinition.tsx
+++ b/src/example/components/parts/WizardScreenDefinition.tsx
@@ -1,0 +1,8 @@
+import {RouteConfig, StackNavigationState} from '@react-navigation/native';
+import {ParamListBase} from '@react-navigation/routers';
+import {PropsWithChildren} from 'react';
+import {NativeStackNavigationEventMap, NativeStackNavigationOptions} from 'react-native-screens/lib/typescript/types';
+
+export type WizardScreenDefinition<ParamList extends ParamListBase> = PropsWithChildren<
+  RouteConfig<ParamList, keyof ParamList, StackNavigationState, NativeStackNavigationOptions, NativeStackNavigationEventMap>
+>;


### PR DESCRIPTION
## やったこと

- [x] Install React Navigation and dependencies
- [x] Add tab navigation examples
- [x] Add stack navigation examples
- [x] Add drawer navigation examples

## やっていないこと

- Describe forward/back navigation routes in this app
  - I cannot define the "standard" navigation using tab and stack now. So, do it in an other pull request
- Add tab/stack combined navigation examples
  - This might not be so easy, so do it in other pull requests
- Handle back action

## 動作確認

- [x] Launch application
- [x] Change screen using Tab Bar (Tab)
- [x] Change screen using Button (Stack)

## デバイス

It's hard to test with actual devices now...

- [x] iOS
  - [x] Simulator (iPhone Xs/iOS 14)
  - [x] Actual Device (iPhone 8/iOS 13)
- [x] Android
  - [x] Emulator (Pixel 3a/Android 11)
  - [x] Actual Device (Pixel 3a/Android 11)

## その他（レビュアーへの申し送り事項、懸念点など）

[AB#4422](https://dev.azure.com/ws-4020/d7a19fb0-b312-4b39-8b66-3fc0f61016f5/_workitems/edit/4422)