### PR TITLE
✨ remove debug.keystore in .gitignore

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -40,6 +40,7 @@ yarn-error.log
 buck-out/
 \.buckd/
 *.keystore
+!debug.keystore
 
 # fastlane
 #


### PR DESCRIPTION

## やったこと
debug.keystore is needed for android app build. 
We have to commit this file so that developers can build and debug an app.

- [x] remove debug.keystore in .gitignore

## やっていないこと

Nothing

## 動作確認

Nothing

## デバイス

Nothing

## その他（レビュアーへの申し送り事項、懸念点など）

Nothing
