### PR TITLE
✨: Initialize the project after creating from template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+# https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+
+[*.{ts,tsx,js,jsx,json}]
+
+# インデントにはスペースを利用する。
+indent_style = space
+# インデントサイズは2。
+indent_size = 2
+# タブ文字は8文字幅で表示する。（Tabが紛れていることがわかりやすくなるように）
+tab_width = 8
+# 改行コードはLFに統一する。（batなど一部のファイルの改行コードは.gitattributesで強制的にCRLFに変更されます。）
+end_of_line = lf
+# 文字コードはUTF-8
+charset = utf-8
+# 行末の空白はトリムする。
+trim_trailing_whitespace = true
+# ファイル末尾に改行を入れる。
+insert_final_newline = true
+# 一行の長さは150文字まで。
+max_line_length = 150

--- a/post-init.js
+++ b/post-init.js
@@ -1,15 +1,60 @@
 #!/usr/bin/env node
 
-const copyIosPersonalAccountConfig = async () => {};
-const generateAndroidDebugKeystore = async () => {};
+const fs = require("fs");
+const fsp = require("fs/promises");
+const { spawn } = require("child_process");
 
-const main = async () => {
-  await Promise.all([
-    copyIosPersonalAccountConfig(),
-    generateAndroidDebugKeystore(),
-  ]);
+const copyIosPersonalAccountConfig = async () => {
+  const file = "ios/PersonalAccount.xcconfig";
+  await fsp.copyFile(`${file}.template`, `${file}`, fs.constants.COPYFILE_EXCL).then(() => {
+    console.log("  ✔ Copy configuration file to set your Apple ID");
+  });
 };
 
-// Promise is handled by caller.
-// noinspection JSIgnoredPromiseFromCall
-main();
+const generateAndroidDebugKeystore = async () => {
+  const file = "android/app/debug.keystore";
+  if (fs.existsSync(file)) {
+    await fsp.unlink(file);
+  }
+  const command = {
+    command: "keytool",
+    args: [
+      "-genkey",
+      "-v",
+      "-keystore",
+      "android/app/debug.keystore",
+      "-storepass",
+      "android",
+      "-alias",
+      "androiddebugkey",
+      "-keypass",
+      "android",
+      "-dname",
+      "'CN=Android Debug,O=Android,C=US'",
+    ],
+  };
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    const process = spawn(command.command, command.args, { shell: true });
+    process.stdout.on("data", (chunk) => (stdout += chunk));
+    process
+      .on("error", () => reject(stdout))
+      .on("close", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(stdout);
+        }
+      });
+  }).then(() => console.log("  ✔ Generate debug.keystore file"));
+};
+
+const main = async () => {
+  await Promise.all([copyIosPersonalAccountConfig(), generateAndroidDebugKeystore()]);
+};
+
+main().catch((reason) => {
+  console.log(); // 標準出力上でログを見やすくするために、一行改行しています。
+  console.error(reason);
+  process.exit(1);
+});


### PR DESCRIPTION
## やったこと

- [x] Add PersonalAccount.xcconfig
- [x] Generate debug.keystore

## やっていないこと

None

## 動作確認

- [x] `npx react-native init --template https://github.com/ws-4020/rn-spoiler#feature/add-post-init-script YourAppName`
- [x] `npm run ios`
- [x] `npm run android`

## デバイス

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] ~~実機 (iPhone 8/iOS 14)~~
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] ~~実機 (Pixel 3a/Android 11)~~

## その他（レビュアーへの申し送り事項、懸念点など）

* [AB#4663](https://dev.azure.com/ws-4020/d7a19fb0-b312-4b39-8b66-3fc0f61016f5/_workitems/edit/4663)
* [AB#5019](https://dev.azure.com/ws-4020/d7a19fb0-b312-4b39-8b66-3fc0f61016f5/_workitems/edit/5019)