### PR TITLE
🐛: Use promises in `fs` module instead of `fs/promises`

### DIFF
--- a/post-init.js
+++ b/post-init.js
@@ -30,13 +30,14 @@ const generateAndroidDebugKeystore = async () => {
       "-keypass",
       "android",
       "-dname",
-      "'CN=Android Debug,O=Android,C=US'",
+      '"CN=Android Debug,O=Android,C=US"',
     ],
   };
   return new Promise((resolve, reject) => {
     let stdout = "";
     const process = spawn(command.command, command.args, { shell: true });
     process.stdout.on("data", (chunk) => (stdout += chunk));
+    process.stderr.on("data", (chunk) => (stdout += chunk));
     process
       .on("error", () => reject(stdout))
       .on("close", (code) => {
@@ -55,6 +56,6 @@ const main = async () => {
 
 main().catch((reason) => {
   console.log(); // 標準出力上でログを見やすくするために、一行改行しています。
-  console.error(reason);
+  console.log(reason);
   process.exit(1);
 });

--- a/post-init.js
+++ b/post-init.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require("fs");
-const fsp = require("fs/promises");
+const fsp = require("fs").promises;
 const { spawn } = require("child_process");
 
 const copyIosPersonalAccountConfig = async () => {

--- a/post-init.js
+++ b/post-init.js
@@ -56,6 +56,6 @@ const main = async () => {
 
 main().catch((reason) => {
   console.log(); // 標準出力上でログを見やすくするために、一行改行しています。
-  console.log(reason);
+  console.error(reason);
   process.exit(1);
 });


### PR DESCRIPTION
## やったこと

- [x] Change `require("fs/promises")` to `requre("fs").promises`
- [x] Use double-quote to quote parameters in command

## やっていないこと

None

## 動作確認

Run `npx react-native init --template https://github.com/ws-4020/rn-spoiler#feature/fix-post-init YourAppName`

| OS | Node.js version | before | after |
|---|---|---|---|
| Windows 10 | 12 | ❌ | ✅ |
| Windows 10 | 14 | ❌ | ✅ |
| macOS Catalina | 12 | ❌ | ✅ |
| macOS Catalina | 14 | ✅ | ✅ |

## デバイス

None

## その他（レビュアーへの申し送り事項、懸念点など）

[AB#5062](https://dev.azure.com/ws-4020/d7a19fb0-b312-4b39-8b66-3fc0f61016f5/_workitems/edit/5062)