### PR TITLE
一行120文字までにする

### DIFF
--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -18,5 +18,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 # ファイル末尾に改行を入れる。
 insert_final_newline = true
-# 一行の長さは150文字まで。
-max_line_length = 150
+# 一行の長さは120文字まで。
+max_line_length = 120


### PR DESCRIPTION
## 💣 BREAKING CHANGE 💣

- 一行が150文字だと横スクロールが発生するので120文字にしてみる

## やったこと

- [ ] このブランチのrn-spoilerで作成したプロジェクトでコード書いてみて、違和感がないレベルで改行されること

## やっていないこと


## 動作確認

- [ ] このブランチのテンプレートでプロジェクトを作成する
- [ ] コードを書いてみて適切な改行がされることを確認する

## デバイス

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## その他（レビュアーへの申し送り事項、懸念点など）

なし