### PR TITLE
⬆️: Bump Flipper version to fix iOS build failure

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -26,4 +26,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.54.0
+FLIPPER_VERSION=0.74.0

--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				AF7BF8C823CE838DA4182532 /* [CP] Copy Pods Resources */,
+				DC1CA795768B49C212EF845E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -247,6 +248,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DC1CA795768B49C212EF845E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -14,7 +14,7 @@ target 'HelloWorld' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  use_flipper!({ 'Flipper' => '0.74.0' }, configurations: ['Debug', 'DebugAdvanced'])
   post_install do |installer|
     flipper_post_install(installer)
   end


### PR DESCRIPTION
## ✅ What's done

- [x] Flipperのバージョンを`0.54`から`0.74`に更新
  - iOSでのビルドエラーの回避のため

---

<!-- 上の区切りまでが、マージされるときにコミットメッセージとして使われます。 -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `npm run ios`でエラーが発生せずにアプリが起動すること
- [x] ~~`npm run ios -- --configuration=Release`でエラーが発生せずにアプリが起動すること~~
  - エラーになる。 #46 と合わせて解消。
- [x] `npm run android`でエラーが発生せずにアプリが起動すること
- [x] `npm run android -- --variant=release`でエラーが発生せずにアプリが起動すること

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] ~~実機 (iPhone 8/iOS 14)~~
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] ~~実機 (Pixel 3a/Android 11)~~

## Other (messages to reviewers, concerns, etc.)

iOSのリリースビルドはエラーになります。 #46 と合わせて解消されます。