### PR TITLE
Home, Instructionをscreensモジュールからimportするよう修正

### DIFF
--- a/template/src/navigation/RootStackNav.tsx
+++ b/template/src/navigation/RootStackNav.tsx
@@ -1,7 +1,6 @@
 import {createStackNavigator} from '@react-navigation/stack';
 import React from 'react';
-import {Home} from 'screens/home';
-import {Instructions} from 'screens/instructions';
+import {Home, Instructions} from 'screens';
 
 const nav = createStackNavigator();
 export const RootStackNav: React.FC = () => {


### PR DESCRIPTION
## ✅ What's done

- [x] Home, Instructionをscreensモジュールからimportするよう修正

## Devices

- [x] 動作確認に利用したデバイスにチェックをつけてください
- [x] iOS
  - [ ] シミュレータ (iPhone Xs/iOS 14)
  - [x] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [ ] エミュレータ (Pixel 3a/Android 11)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

```
npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler#fix/RootStackNav-import-screens todo_app
```

上記コマンドで作成したプロジェクトがExpoで動作するところまで確認しています。
