### PR TITLE
🐛: Fix app crash on iOS with DebugAdvanced configuration

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,6 +4,11 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 platform :ios, '11.0'
 
+project 'HelloWorld',
+  'Debug' => :debug,
+  'DebugAdvanced' => :debug,
+  'Release' => :release
+
 target 'HelloWorld' do
   use_unimodules!
   config = use_native_modules!


### PR DESCRIPTION
## ✅ What's done

- [x] `DebugAdvanced` Configuration ではデバッグビルドするようにPodfileを修正
---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler.git#hotfix/crash-on-debug-advanced RnSpoiler2` でプロジェクトを作成できること
- [x] `npm run ios -- --configuration DebugAdvanced` でアプリが正常に起動すること

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] ~~実機 (iPhone 8/iOS 14)~~
- [x] ~~Android~~

## Other (messages to reviewers, concerns, etc.)

`DebugAdvanced` Configurationでデバッグモードでビルドするように設定していなかったため、アプリを起動すると「No bundle URL present」のようなエラーが発生してしまっていました。
`Podfile`に設定を追加し、エラーを回避しています。`Debug`, `Release`はデフォルトで設定されるのですが、なぜ`DebugAdvanced`だけ設定しているのかわからなくなると思い、明示的に設定するようにしています。