### PR TITLE
🔧: Add Config.xcconfig to make personal account configuration optional

### DIFF
--- a/post-init.js
+++ b/post-init.js
@@ -4,13 +4,6 @@ const fs = require("fs");
 const fsp = require("fs").promises;
 const { spawn } = require("child_process");
 
-const copyIosPersonalAccountConfig = async () => {
-  const file = "ios/PersonalAccount.xcconfig";
-  await fsp.copyFile(`${file}.template`, `${file}`, fs.constants.COPYFILE_EXCL).then(() => {
-    console.log("  ✔ Copy configuration file to set your Apple ID");
-  });
-};
-
 const generateAndroidDebugKeystore = async () => {
   const file = "android/app/debug.keystore";
   if (fs.existsSync(file)) {
@@ -55,7 +48,7 @@ const generateAndroidDebugKeystore = async () => {
 };
 
 const main = async () => {
-  await Promise.all([copyIosPersonalAccountConfig(), generateAndroidDebugKeystore()]);
+  await Promise.all([generateAndroidDebugKeystore()]);
 };
 
 main().catch((reason) => {

--- a/template/README.md
+++ b/template/README.md
@@ -11,16 +11,24 @@
 
 ## アプリをビルドしてiOSデバイスにインストールする
 
+0. `ios-deploy --version`を実行して、インストール済みの`ios-deploy`のバージョンが表示されることを確認してください。
+   * エラーになった場合は、[ios-deploy](https://github.com/ios-control/ios-deploy)をインストールしてください。
 1. `ios/PersonalAccount.xcconfig.template` を `ios/PersonalAccount.xcconfig` としてコピーしてください。
 2. ファイルに記載されている設定値を、それぞれ次のように設定してください。
    * `CODE_SIGN_STYLE`: Automatic
    * `PERSONAL_IDENTIFIER`: 他の人とかぶらない、何らかの一意の値
    * `DEVELOPMENT_TEAM`: 個人のApple IDに割り当てられたID
-3. ルートディレクトリで`xed ios`と実行して、Xcodeでプロジェクトを開いてください。
-4. Xcode上で署名情報を確認し、エラーが発生していないことを確認してください
-5. ルートディレクトリで次のコマンドを実行してください。`<device name>`はインストール先のiOSデバイス名です。
+     * わからない場合は、[個人のApple IDでのチームIDの確認方法](#個人のapple-idでのチームidの確認方法)の手順で確認してください。
+3. ルートディレクトリで`xed ios`と実行して、Xcodeでプロジェクトを開いてください。開くだけで良いようです。
+4. ルートディレクトリで次のコマンドを実行してください。`<device name>`はインストール先のiOSデバイス名です。
    * `npm run ios -- --device='<device name>'`
    * デバイス名、シミュレータ名の一覧は `xcrun xctrace list devices` で取得することができます。
+
+> **Note**: Xcodeで一度もプロジェクトを開かずにデバイスにインストールしようとすると、次のようなエラーが発生します。
+> ```
+> error: No profiles for 'personal.org.name.RnSpoiler.<personal>' were found: Xcode couldn't find any iOS App Development provisioning profiles matching 'personal.org.name.RnSpoiler.<personal>'. Automatic signing is disabled and unable to generate a profile. To enable automatic signing, pass -allowProvisioningUpdates to xcodebuild. (in target 'RnSpoiler' from project 'RnSpoiler')
+> ```
+> このようなエラーが発生した場合は、一度Xcodeでプロジェクトを開いてからデバイスへのインストールを試してください。
 
 ### 個人のApple IDでのチームIDの確認方法
 
@@ -28,7 +36,7 @@
 
 1. Xcodeでアカウントの設定画面を開き、必要ならログインします。
    * Xcode 12では、「Preferences」＞「Accounts」でアカウントの設定画面を開けます
-   * ログインする場合、左下の「＋」ボタンをクリックしてログインます。
+   * ログインする場合、左下の「＋」ボタンをクリックしてログインします。
 2. 利用するApple IDを選択状態にし、右側のチーム一覧で「<自分の氏名> (Personal Team)」と書かれているチームを選択します。
    * Apple Developer Programなどに登録されているユーザの場合、Apple Developer Programのデベロッパー名なども表示されるため、複数のチームが表示されます。
 3. 「Personal Team」を選択した状態で「Manage Certificates」をクリックします。

--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		96905EF65AED1B983A6B3ABC /* libPods-HelloWorld.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-HelloWorld.a */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		EA57F9FF253825A7003D7604 /* PersonalAccount.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EA57F9FE253825A7003D7604 /* PersonalAccount.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,8 +30,8 @@
 		6C2E3173556A471DD304B334 /* Pods-HelloWorld.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld.debug.xcconfig"; path = "Target Support Files/Pods-HelloWorld/Pods-HelloWorld.debug.xcconfig"; sourceTree = "<group>"; };
 		7A4D352CD337FB3A3BF06240 /* Pods-HelloWorld.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld.release.xcconfig"; path = "Target Support Files/Pods-HelloWorld/Pods-HelloWorld.release.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		B96BE75C25FED2460098969A /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = HelloWorld/Config.xcconfig; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		EA57F9FE253825A7003D7604 /* PersonalAccount.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PersonalAccount.xcconfig; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
@@ -56,6 +55,7 @@
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				B96BE75C25FED2460098969A /* Config.xcconfig */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
@@ -85,7 +85,6 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
-				EA57F9FE253825A7003D7604 /* PersonalAccount.xcconfig */,
 				13B07FAE1A68108700A75B9A /* HelloWorld */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
@@ -186,7 +185,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
-				EA57F9FF253825A7003D7604 /* PersonalAccount.xcconfig in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
@@ -370,7 +368,7 @@
 		};
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EA57F9FE253825A7003D7604 /* PersonalAccount.xcconfig */;
+			baseConfigurationReference = B96BE75C25FED2460098969A /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/template/ios/HelloWorld/Config.xcconfig
+++ b/template/ios/HelloWorld/Config.xcconfig
@@ -1,0 +1,7 @@
+//
+//  Config.xcconfig
+//  HelloWorld
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+#include? "../PersonalAccount.xcconfig"


### PR DESCRIPTION
## ✅ What's done

- [x] `template/ios/HelloWorld/Config.xcconfig`を追加
- [x] `ios/PersonalAccount.xcconfig`は、`Config.xcconfig`から読み込むように変更
- [x] `ios/PersonalAccount.xcconfig`が存在しなくてもエラーにならないように変更
- [x] プロジェクト作成後に`PersonalAccount.xcconfig`を作成しないように変更
- [x] README.mdに`ios-deploy`のインストールについて追記
---

## Tests

- [x] `npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler.git#feature/add-xcconfig RnSpoiler` でプロジェクトを作成できること
- [x] 作成されたプロジェクトに`ios/PersonalAccount.xcconfig`が含まれていないこと
- [x] 作成した直後に`npm run ios`でシミュレータ上で起動できること
- [x] README.mdの記載に沿って準備することで、`npm run ios -- --device <xxxx>`で実機上にインストールできること

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] 実機 (iPhone 8/iOS 14)
- [x] ~~Android~~

## Other (messages to reviewers, concerns, etc.)

`ios/PersonalAccount.xcconfig`はignoreされているにも関わらず、ファイルが存在しないとシミュレータでもアプリを起動できませんでした。
これではわかりにくくハマりやすいと思うので、ファイルが存在しなくてもシミュレータでは起動できるように修正しました。