### PR TITLE
⬆️: Update dependency react-native-reanimated to ~2.0.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -29,7 +29,7 @@
     "react-native": "0.63.4",
     "react-native-elements": "~3.2.0",
     "react-native-gesture-handler": "~1.8.0",
-    "react-native-reanimated": "~1.13.0",
+    "react-native-reanimated": "~2.0.0",
     "react-native-safe-area-context": "3.1.9",
     "react-native-screens": "~2.15.2",
     "react-native-unimodules": "~0.12.0",


### PR DESCRIPTION
## ✅ What's done

- [x] React Native Reanimated をメジャーバージョンアップ
---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] `npm run android`
- [x] `npm run ios`

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
  - [x] 実機 (iPhone 8/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] 実機 (Pixel 4a/Android 11)

## Other (messages to reviewers, concerns, etc.)

React Native Reanimatedの1系だとAndroidアプリのビルドでJavadocエラーが発生するようになってしまいました。
2系は基本的に1系と互換性を保っていること、2系のAPIの方が利用しやすいことから、このタイミングでバージョンアップしたいです。
https://docs.swmansion.com/react-native-reanimated/docs/migration