### PR TITLE
🔨: Import Expo SDK 40 template updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,16 @@ keytool -genkey -v -keystore android/app/debug.keystore -storepass android -alia
 ## `expo-template-bare-typescript` からの変更点
 
 - [x] デフォルトでは`expo-update`を無効化
-- [x] Editorconfig, ESLint, Prettier を追加
-- [x] TypeScript の設定ファイルを修正、`tsc`での型チェックを lint に追加
-- [x] Android でデフォルトで要求するパーミッションの最小化
+- [x] Editorconfig, ESLint, Prettierを追加
+- [x] TypeScriptの設定ファイルを修正、`tsc`での型チェックをlintに追加
+- [x] Androidでデフォルトで要求するパーミッションの最小化
 - [x] `App.tsx`を`src`ディレクトリ配下に移動
-- [x] 開発者ごとに簡単に Signing できるように、Signing 情報を記述するテンプレートファイルを iOS のビルド設定に追加
-- [x] UI ライブラリとして[React Native Elements](https://reactnativeelements.com/)を追加
+- [x] 開発者ごとに簡単にSigningできるように、Signing情報を記述するテンプレートファイルをiOSのビルド設定に追加
+- [x] UIライブラリとして[React Native Elements](https://reactnativeelements.com/)を追加
 - [x] ナビゲーションに[React Navigation](https://reactnavigation.org/)を追加、画面を修正
 - [x] React Native の使い方ページを、 [react-native-template-typescript](https://github.com/react-native-community/react-native-template-typescript) から追加。
   - `src/screens/instructions/Instructions.tsx` は、[react-native-template-typescript](https://github.com/react-native-community/react-native-template-typescript) に含めて配布されている [`App.tsx`](https://github.com/react-native-community/react-native-template-typescript/blob/60690d1f7f3c2856d4c7129fd972400452c9510d/template/App.tsx) を利用しています。
 - [x] Jestの設定を`jest.config.js`に移動し、`react-navigation`と`react-native-screens`に必要なネイティブモジュールをモック化
-- [x] Jestのスナップショットファイルの配置場所を変更
 - [x] `src`ディレクトリを基準とした絶対パスで`import`できるように変更
 - [x] プロジェクト作成後に自動的に必要なファイルを作成するように変更
 - [x] キャッシュを削除するためのスクリプトを追加

--- a/template/_gitignore
+++ b/template/_gitignore
@@ -29,6 +29,7 @@ build/
 .gradle
 local.properties
 *.iml
+*.hprof
 
 # node.js
 #

--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx10248m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/template/ios/HelloWorld/AppDelegate.m
+++ b/template/ios/HelloWorld/AppDelegate.m
@@ -67,7 +67,6 @@ static void InitializeFlipper(UIApplication *application) {
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;

--- a/template/package.json
+++ b/template/package.json
@@ -36,7 +36,7 @@
     "react-native-web": "~0.13.12"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
+    "@babel/core": "^7.9.0",
     "@types/jest": "<26.0.0",
     "@types/react": "~16.9.35",
     "@types/react-dom": "~16.9.8",


### PR DESCRIPTION
## ✅ What's done

- [x] Ignore hprof files and bump JVM heap size
- [x] Remove extra window initialization
- [x] Refine README
---

## Tests

- [x] `npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler.git#feature/catch-up-to-expo-sdk-40-template RnSpoiler` でプロジェクトを作成できること
- [x] 作成した直後に`npm run android`でシミュレータ上で起動できること
- [x] 作成した直後に`npm run ios`でシミュレータ上で起動できること
- [x] `expo-template-bare-typescript`で作成したプロジェクトとの差分がすべてREADME.mdに記載されていること

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone 11/iOS 13.5)
  - [x] ~~実機 (iPhone 8/iOS 14.4)~~
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)
  - [x] ~~実機 (Pixel 4a/Android 11)~~

## Other (messages to reviewers, concerns, etc.)

なし