### PR TITLE
🔨: Remove pod update from reset-cache script

### DIFF
--- a/template/.script/jobs/reset-cache-macos.js
+++ b/template/.script/jobs/reset-cache-macos.js
@@ -74,22 +74,6 @@ module.exports = [
     ],
   },
   {
-    name: 'Update CocoaPods dependency',
-    enabled: false,
-    commands: [
-      {
-        command: 'ls',
-        args: ['Pods'],
-        cwd: 'ios',
-      },
-      {
-        command: 'pod',
-        args: ['update'],
-        cwd: 'ios',
-      },
-    ],
-  },
-  {
     name: 'Delete ios/Pods directory',
     enabled: true,
     commands: [


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- キャッシュのリセットをするときにPodsをアップデートしないように修正
---

## Tests

- [x] `npm run -s template reset-cache:all`

## Other (messages to reviewers, concerns, etc.)

キャッシュを消したつもりが、Podsまで更新されてしまうのは意図しない気がします、、、