### PR TITLE
📌: Flipperが依存しているPodsのバージョンを固定

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -26,4 +26,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.74.0
+FLIPPER_VERSION=0.87.0

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -16,7 +16,7 @@ target 'HelloWorld' do
   use_react_native!(:path => config["reactNativePath"])
 
   if !ENV['CI']
-    use_flipper!({ 'Flipper' => '0.80.0' }, configurations: ['Debug', 'DebugAdvanced'])
+    use_flipper!({ 'Flipper' => '0.87.0', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1' }, configurations: ['Debug', 'DebugAdvanced'])
     post_install do |installer|
       flipper_post_install(installer)
     end


### PR DESCRIPTION
## ✅ What's done

- [x] Flipper-Follyのバージョンを`2.5.3`に固定
- [x] Flipper-RSocketのバージョンを`1.3.1`に固定
- [x] Flipperのバージョンを`0.87.0`に更新
---

## Tests

- [x] `npm run ios`
- [x] `npm run android`

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone Xs/iOS 14)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

Flipperの0.88.0は、Flipper-Follyの2.6以上とFlipper-RSocketの1.4以上を要求します。それぞれXcode 12.5でコンパイルエラーが発生する状態なので、現時点では0.88.0には更新できません。
