### PR TITLE
🐛: Semantic Versioningの命名規約に従うようにバージョン名を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ws-4020/rn-spoiler",
-  "version": "2021.05.0",
+  "version": "2021.5.0",
   "description": "ws-4020 React Native Boilerplate",
   "private": true,
   "repository": {


### PR DESCRIPTION
## ✅ What's done

- [x] バージョン名を`2021.5.0`に変更
  - `2021.05.0`というバージョン名はSemantic Versioningの命名規約違反
  - このため、Yarnを使うようにプロジェクトを新規作成しようとしても失敗する

## ⏸ What's not done

- GitHub リリース名とタグ名の修正
---

## Tests

- [x] `npx react-native init --template https://github.com/ws-4020/rn-spoiler#hotfix/fix-package-version RnSpoilerYarn`
  - Yarnがグローバルにインストールされている環境で実行
- [x] `npx react-native init --npm --template https://github.com/ws-4020/rn-spoiler#hotfix/fix-package-version RnSpoilerYarn`

## Other (messages to reviewers, concerns, etc.)

[Semantic Versioningの仕様](https://semver.org/lang/ja/#spec-item-2)
> 通常のバージョンナンバーは、X.Y.Zの形式にしなければなりません（MUST）。このときX、Y、Zは非負の整数であり（MUST）、各数値の先頭にゼロを配置してはなりません（MUST NOT）。

RN Spoilerのバージョニングは、セマンティックバージョニングに従う必要はありません。ただ、Yarnがインストールされた環境で`react-native init`するとデフォルトではYarnが選択されてしまい、エラーになってしまうので修正したほうがいいと思います。