### PR TITLE
🐛: expo-template-bare-typescriptのリンク先をSDK 41のURLに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RN Spoiler
 
-[Expo](https://expo.io/) の [expo-template-bare-typescript](https://github.com/expo/expo/tree/master/templates/expo-template-bare-typescript) をベースにした React Native のテンプレートです。
+[Expo](https://expo.io/) の [expo-template-bare-typescript](https://github.com/expo/expo/tree/sdk-41/templates/expo-template-bare-typescript) をベースにした React Native のテンプレートです。
 
 ## 前提条件
 


### PR DESCRIPTION
## ✅ What's done

- [x] `expo-template-bare-typescript`のリンク先を、SDK 41のURLに修正
---

## Other (messages to reviewers, concerns, etc.)

元にしているのはSDK 41のテンプレートなので、そのように修正

fix #67 
