### PR TITLE
🐛: パッチファイル内のpackage.jsonのexpo、react-nativeのバージョンを更新

### DIFF
--- a/example/hands-on/patches/06-login-screen.patch
+++ b/example/hands-on/patches/06-login-screen.patch
@@ -3,17 +3,17 @@ index b38b1fa..9ab32d9 100644
 --- a/package.json
 +++ b/package.json
 @@ -24,6 +24,7 @@
-     "expo": "^41.0.0",
-     "expo-splash-screen": "~0.10.2",
-     "expo-updates": "~0.5.4",
+     "expo": "^42.0.0",
+     "expo-splash-screen": "~0.11.2",
+     "expo-updates": "~0.8.1",
 +    "formik": "^2.2.6",
      "react": "16.13.1",
      "react-dom": "16.13.1",
      "react-native": "0.63.4",
 @@ -33,7 +34,8 @@
      "react-native-safe-area-context": "3.2.0",
-     "react-native-screens": "~3.0.0",
-     "react-native-unimodules": "~0.13.3",
+     "react-native-screens": "~3.4.0",
+     "react-native-unimodules": "~0.14.5",
 -    "react-native-web": "~0.13.12"
 +    "react-native-web": "~0.13.12",
 +    "yup": "^0.32.9"


### PR DESCRIPTION
## ✅ What's done

- [x] [Expo SDK 42アップグレード対応](https://github.com/ws-4020/rn-spoiler/pull/73)にともない、作成されるアプリのpackage.jsonが変更になったため、パッチファイル内のpackage.jsonのバージョンを更新（expo、react-native）

---

## Tests

- [x] `npm run create-app:hands-on`を実行し、すべてのパッチがエラーなく適用されること
- [x] 作成したアプリが起動できること

## Devices

- [x] iOS
  - [x] シミュレータ (iPhone 11/iOS 14.5)
- [x] Android
  - [x] エミュレータ (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)

なし