### PR TITLE
🔨: Update Renovate settings to disable unnecessary update requests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,13 +1,20 @@
 // Configuration Options | Renovate docs
 // https://docs.renovatebot.com/configuration-options/
 {
-  addLabels: ['dependencies'],
+  addLabels: [
+    'dependencies'
+  ],
   commitMessagePrefix: '⬆️: ',
-  extends: ['config:base', ':preserveSemverRanges'],
+  extends: [
+    'config:base',
+    ':preserveSemverRanges'
+  ],
   timezone: 'Asia/Tokyo',
   lockFileMaintenance: {
     enabled: true,
-    schedule: ['before 20:00 on sunday'],
+    schedule: [
+      'before 20:00 on sunday'
+    ],
   },
   packageRules: [
     {
@@ -42,17 +49,31 @@
       groupName: 'Depends on Expo version',
       enabled: false,
       matchPackageNames: [
-        '@types/jest', // jest-expo -> jest
-        '@types/react-test-renderer', // jest-expo -> react-test-renderer
-        'react-test-renderer', // react, jest-expo -> react-test-renderer
-        'gradle', // expo-template-bare-typescript
+        // jest-expo -> jest
+        '@types/jest',
+        // react, jest-expo -> react-test-renderer
+        'react-test-renderer',
+        // jest-expo -> react-test-renderer
+        '@types/react-test-renderer',
+        // expo-template-bare-minimum
+        'gradle',
+        // expo-template-bare-minimum
+        'com.android.tools.build:gradle',
       ],
-      matchPackagePrefixes: ['com.facebook.flipper'],
+      matchPackagePrefixes: [
+        'com.facebook.flipper',
+        // FrescoはReact Nativeのドキュメントに記載のあるバージョンを利用するため、Renovateの対象外とします
+        // （expo-template-bare-minimumの更新で、Frescoのバージョンも更新されていく想定をしています。）
+        // cf: https://reactnative.dev/docs/0.64/image, https://reactnative.dev/docs/image
+        'com.facebook.fresco'
+      ],
     },
     {
       // React Navigationの関連パッケージはまとめて更新するようにします
       groupName: 'React Navigation',
-      matchPackagePrefixes: ['@react-navigation/'],
+      matchPackagePrefixes: [
+        '@react-navigation/'
+      ],
     },
     {
       // ツール系のパッケージはまとめて更新するようにします
@@ -62,12 +83,17 @@
         '@typescript-eslint/eslint-plugin',
         '@typescript-eslint/parser',
         'eslint',
-        'eslint-config-universe',
         'jest-junit',
         'npm-run-all',
-        'prettier',
+        'patch-package',
+        'prettier'
       ],
-      matchPackagePrefixes: ['markdownlint', 'textlint'],
+      matchPackagePrefixes: [
+        'markdownlint',
+        'textlint',
+        'stylelint',
+        'eslint'
+      ],
     },
   ],
 }


### PR DESCRIPTION
## ✅ What's done

- [x] `com.facebook.fresco`を除外（React Nativeのドキュメントにバージョンも含めて記載があるため）
---

## Other (messages to reviewers, concerns, etc.)

なし