### PR TITLE
📌: Fix the version of react-native-elements at 3.4.2

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -28,7 +28,7 @@
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-native": "0.69.5",
-    "react-native-elements": "~3.4.0",
+    "react-native-elements": "3.4.2",
     "react-native-gesture-handler": "~2.5.0",
     "react-native-reanimated": "~2.9.1",
     "react-native-safe-area-context": "3.3.2",


### PR DESCRIPTION
## ✅ What's done

- [x] 次の理由により、React Native Elementsのバージョンを3.4.2に固定
  - 3.4.3以降のバージョンをインストールすると、patchが適用されなくなる
  - 3.4.3をインストールすると、ThemeProviderがReact 18で入ったchildren対応がされておらず、型エラーとなる
  - React Native Elementsは今後4系が主流となる

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)

なし