### PR TITLE
💚:fix hands-on-app GitHub action

### DIFF
--- a/.github/workflows/hands-on-app.yaml
+++ b/.github/workflows/hands-on-app.yaml
@@ -9,6 +9,7 @@ on:
       - '*'
     paths:
       - 'template/**'
+      - 'example/hands-on/**'
       - '!**.md'
     types:
       - opened

--- a/.github/workflows/hands-on-app.yaml
+++ b/.github/workflows/hands-on-app.yaml
@@ -9,6 +9,7 @@ on:
       - '*'
     paths:
       - 'template/**'
+      - '!**.md'
     types:
       - opened
       - synchronize

--- a/.github/workflows/hands-on-app.yaml
+++ b/.github/workflows/hands-on-app.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - '*'
     paths:
-      - template/
+      - 'template/**'
     types:
       - opened
       - synchronize

--- a/template/src/App.test.tsx
+++ b/template/src/App.test.tsx
@@ -6,6 +6,7 @@ import {act, create} from 'react-test-renderer';
 import {App} from './App';
 
 jest.useFakeTimers();
+// eslint-disable-next-line jest/expect-expect
 it('renders correctly', async () => {
   // eslint-disable-next-line @typescript-eslint/require-await
   await act(async () => {


### PR DESCRIPTION
## ✅ What's done

- [x] workflows/hands-on-app がほとんど実行されてない問題を修正
- [x] `template/` だけでなく `example/hands-on/` の更新でも workflows/hands-on-app を実行する
- [x] `.md` ファイルの更新では workflows/hands-on-app を実行しない
- [x] `HandsOnApp/src/App.test.tsx` で `Warning:   9:1  warning  Test has no assertions  jest/expect-expect` が出る問題対応

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] workflows/hands-on-app がこのPRで動くこと
  - [x] `example/hands-on/**`: c3c4594e183ccf4ef99d23a306f0c346fab35b28 `trigger-ci(example/hands-on/)`
  - [x] `template/**`: 5d22bee0aefc0b743a08a2211980c0c1961e5ad0 `fix: hands-on-app の lint:es で CIが落ちる問題に対応(eslint-disable jest/expect-expect)`

## Other (messages to reviewers, concerns, etc.)

- 該当actionの追加PR
  - https://github.com/ws-4020/rn-spoiler/pull/96
- `9:1  warning  Test has no assertions  jest/expect-expect` の原因
  - `extends: ['plugin:jest/recommended'],`
  - https://github.com/ws-4020/rn-spoiler/pull/109
    - https://github.com/ws-4020/rn-spoiler/pull/109/commits/189ad729528b0eccc8fda1d769db61790ccc22b1 `Add eslint-plugin-deprecation and eslint-plugin-jest`
- 最近のcommitsのCI pass/fail 確認: https://github.com/ws-4020/rn-spoiler/commits/abe2f0af37742c448f881bc710ca027573f44496
  - たまにpassしている理由は不明
    - 578d49d24a85734d125160862b9a0802caa9897f `⬆️: Upgrade Expo SDK to 44 (#106)`
- master ブランチの時点でCIが落ちる状態だったのが顕在化したPR: https://github.com/ws-4020/rn-spoiler/pull/126
  - なぜ↑のPRだけ該当actionが動いたのかは不明
