### PR TITLE
🔨: npm run android/ios に expo を使用する

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -1,8 +1,8 @@
 {
   "main": "index.js",
   "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "start": "expo start --dev-client",
     "prebuild": "run-s build:plugin && expo prebuild --clean --no-install",


### PR DESCRIPTION
## ✅ What's done

- [x] `npm run android` に `expo` を使用
- [x] `npm run ios` に `expo` を使用

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `create-app:hands-on` 後に `npm run android` でアプリが起動、ログイン、TODO追加・更新ができること
- [x] `create-app:hands-on` 後に `npm run ios` でアプリが起動、ログイン、TODO追加・更新ができること
  - `cp config/plugin/template/ios/HandsOnApp/PersonalAccount.xcconfig{.template,}` を事前に実施済み

<!-- 該当するものがなければ、このセクション（この行から「## Otherの前の行まで）を削除してください。 -->
## Devices

- [ ] 動作確認に利用したデバイスにチェックをつけてください
- [ ] iOS
  - [x] シミュレータ (iPhone 13/iOS 16.1)
  - [ ] 実機 (iPhone 8/iOS 14)
- [ ] Android
  - [x] エミュレータ (Pixel 3a/Android 13)
  - [ ] 実機 (Pixel 3a/Android 11)

## Other (messages to reviewers, concerns, etc.)
### 関連PR
- https://github.com/ws-4020/rn-spoiler/pull/126
  - expo の config pluginを使うように変更