### PR TITLE
⬆️: Update hands-on patch 06-login-screen.patch

### DIFF
--- a/example/hands-on/patches/06-login-screen.patch
+++ b/example/hands-on/patches/06-login-screen.patch
@@ -1,15 +1,15 @@
 diff --git a/package.json b/package.json
-index e995ccb..3481915 100644
+index cb8af47..5f64535 100644
 --- a/package.json
 +++ b/package.json
-@@ -28,6 +28,7 @@
-     "expo": "~46.0.19",
+@@ -29,6 +29,7 @@
      "expo-build-properties": "~0.3.0",
      "expo-splash-screen": "~0.16.2",
-+    "formik": "^2.2.6",
      "expo-status-bar": "~1.4.0",
++    "formik": "^2.2.6",
      "react": "18.0.0",
      "react-dom": "18.0.0",
+     "react-native": "0.69.9",
 @@ -37,7 +38,8 @@
      "react-native-reanimated": "~2.9.1",
      "react-native-safe-area-context": "3.3.2",


### PR DESCRIPTION
## ✅ What's done

- [x] Expo、react-nativeのパッチバージョンが更新されたことに伴うHands-onアプリのパッチファイル更新
- [x] dependenciesのsort

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `npm run create-app:hands-on`

## Other (messages to reviewers, concerns, etc.)

dependenciesをsortしたことで、パッチファイルの差分から`expo`が消えて、`react-native`が追加されてます。
