### PR TITLE
🧑‍💻: expo関連ライブラリの自動更新対象外を有効化

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,8 +38,11 @@
         '@types/react',
         'babel-preset-expo',
         'expo',
+        'expo-build-properties',
         'expo-splash-screen',
+        'expo-status-bar',
         'jest',
+        'jest-expo',
         'react',
         'react-native',
         'react-native-gesture-handler',
@@ -54,6 +57,8 @@
       groupName: 'Depends on Expo version',
       enabled: false,
       matchPackageNames: [
+        // expo -> @expo/cli
+        '@expo/config-plugins',
         // jest-expo -> jest
         '@types/jest',
         // react, jest-expo -> react-test-renderer


### PR DESCRIPTION
## ✅ What's done
expoによる管理対象であるため以下をrenovate対象外に指定

- expo-build-properties
- expo-status-bar
- jest-expo
- @expo/config-plugins

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Other (messages to reviewers, concerns, etc.)
関連PR
- https://github.com/ws-4020/rn-spoiler/pull/141
- https://github.com/ws-4020/rn-spoiler/pull/142

参考PR
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1190