### PR TITLE
🧪: create-app:hands-onのfail対応

### DIFF
--- a/example/hands-on/patches/06-login-screen.patch
+++ b/example/hands-on/patches/06-login-screen.patch
@@ -8,7 +8,7 @@ index cc5c15d..f3d20e0 100644
      "expo-status-bar": "~1.4.2",
 +    "formik": "^2.2.6",
      "react": "18.2.0",
-     "react-native": "0.71.7",
+     "react-native": "0.71.8",
      "react-native-elements": "~3.4.0",
      "react-native-gesture-handler": "~2.9.0",
      "react-native-reanimated": "~2.14.4",


### PR DESCRIPTION
## 原因
react-native version upによるpackage.jsonのパッチファイル適用失敗

## ✅ What's done

- パッチファイルの `react-native` バージョンを更新

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- GitHub Actions で Create HandsOn App (`npm run create-app:hands-on`)が成功


## Other (messages to reviewers, concerns, etc.)
### エラーログ
```
error: patch failed: package.json:29
error: package.json: patch does not apply

Command failed. cmd: [git apply --whitespace=nowarn ../../patches/06-login-screen.patch] code: [1]
```

### 発生した理由
masterブランチで落ちるようになっているのは templateに`package-lock.json`が含まれていないため