### PR TITLE
✨: templateにVSCode用設定を追加

### DIFF
--- a/template/.vscode/extensions.json
+++ b/template/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint":true
+  },
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ]
+}

--- a/template/README.md
+++ b/template/README.md
@@ -8,6 +8,7 @@
     - WindowsでChocolateyでインストールする場合は、 `node-lts` パッケージをおすすめします。
   - 「Development OS」は、開発に利用している OS を選択してください。
   - （macOSのみ）「Target OS」は、「iOS」「Android」の両方の手順を実施してください。
+- Visual Studio Code用の設定が含まれています。`Extensions`→`Recommended`で表示される`WORKSPACE RECOMMENDATIONS`に表示される拡張機能をインストールすると、ファイル保存時の自動formatなどが働くようになります。
 
 ## 依存パッケージのインストール
 


### PR DESCRIPTION
## ✅ What's done

- `template/.vscode`フォルダの設定ファイルを追加
- `template/README.md`に推奨拡張・設定について追記

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

- [x] `npx react-native init` で `.vscode`フォルダのファイルが存在すること
- [x] 拡張機能を入れてあればファイル保存でフォーマット/修正されること

## Other (messages to reviewers, concerns, etc.)
### 関連
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1249
- https://github.com/ws-4020/mobile-app-crib-notes/pull/1285