### PR TITLE
🩹: 最新のreact-nativeコマンドで動かないのでv0.75.4を明示

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ npm ls -g --depth=0
 次のコマンドを実行して、新規プロジェクトを作成できます。
 
 ```bash
-npx react-native init --template https://github.com/ws-4020/rn-spoiler.git <YourAppName>
+npx react-native@0.75.4 init --template https://github.com/ws-4020/rn-spoiler.git <YourAppName>
 ```
 
 `<YourAppName>` に設定した名前でディレクトリが作成されます。

--- a/example/hands-on/create-hands-on-app.js
+++ b/example/hands-on/create-hands-on-app.js
@@ -66,7 +66,7 @@ async function main() {
 
     // rn-spoilerをテンプレートとして、新規アプリを作成
     await execute(generatedDir,
-      `npx react-native init --npm --template ${options.template} ${appName}`);
+      `npx react-native@0.75.4 init --npm --template ${options.template} ${appName}`);
 
     // npm7以上の場合は、エラーが発生するので対処
     // https://github.com/ws-4020/rn-spoiler#%E6%96%B0%E8%A6%8F%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E4%BD%9C%E6%88%90


### PR DESCRIPTION
## ✅ What's done

- [x] npx react-nativeコマンドにversionを明示(@0.75.4)
   - 理由: v0.76.0以降だと失敗するようになったため

## ⏸ What's not done

- 恒久対応(2024/12/31までに必要)

---

<!-- 上の区切りまでを、Auto-mergeを設定するときにコミットメッセージとして設定してください -->

## Tests

* [x]  変更前のコマンド ` npx react-native init ～ `を使った`npm run create-app:hands-on`だと失敗することを確認(後述)
* [x]  変更後のコマンド ` npx react-native@0.75.4 init ～ `を使った`npm run create-app:hands-on`で成功することを確認(後述)
* [x]  他のファイルに` react-native init `がないこと

```
$ git grep 'react-native init' v2024.10.0
v2024.10.0:README.md:npx react-native init --template https://github.com/ws-4020/rn-spoiler.git <YourAppName>
v2024.10.0:example/hands-on/create-hands-on-app.js:      `npx react-native init --npm --template ${options.template} ${appName}`);

$ git grep 'react-native init' | wc --lines
0
```

### 変更前
```
$ npm run create-app:hands-on

> @ws-4020/rn-spoiler@2021.5.0 create-app:hands-on
> node example/hands-on/create-hands-on-app.js

Start creating HandsOnApp.

⚠️ The `init` command is deprecated.
The behavior will be changed on 2024/12/31 (36 days).

- Switch to npx @react-native-community/cli init for the identical behavior.
- Refer to the documentation for information about alternative tools: https://reactnative.dev/docs/getting-started

Running: npx @react-native-community/cli init

node:events:497
      throw er; // Unhandled 'error' event
      ^

Error: spawn npx ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:292:12)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npx',
  path: 'npx',
  spawnargs: [
    '@react-native-community/cli@latest',
    'init',
    '--npm',
    '--template',
    'file://path-to',
    'HandsOnApp'
  ]
}

Node.js v20.17.0
```

### 変更後
```
$ npm run create-app:hands-on

> @ws-4020/rn-spoiler@2021.5.0 create-app:hands-on
> node example/hands-on/create-hands-on-app.js

Start creating HandsOnApp.

⚠️ The `init` command is deprecated.
The behavior will be changed on 2024/12/31 (36 days).

- Switch to npx @react-native-community/cli init for the identical behavior.
- Refer to the documentation for information about alternative tools: https://reactnative.dev/docs/getting-started

Running: npx @react-native-community/cli init


               ######                ######
             ###     ####        ####     ###
            ##          ###    ###          ##
            ##             ####             ##
            ##             ####             ##
            ##           ##    ##           ##
            ##         ###      ###         ##
             ##  ########################  ##
          ######    ###            ###    ######
      ###     ##    ##              ##    ##     ###
   ###         ## ###      ####      ### ##         ###
  ##           ####      ########      ####           ##
 ##             ###     ##########     ###             ##
  ##           ####      ########      ####           ##
   ###         ## ###      ####      ### ##         ###
      ###     ##    ##              ##    ##     ###
          ######    ###            ###    ######
             ##  ########################  ##
            ##         ###      ###         ##
            ##           ##    ##           ##
            ##             ####             ##
            ##             ####             ##
            ##          ###    ###          ##
             ###     ####        ####     ###
               ######                ######


                  Welcome to React Native!
                 Learn once, write anywhere

warn Flag --npm is deprecated and will be removed soon. In the future, please use --pm npm instead.
- Downloading template
√ Downloading template
- Copying template
√ Copying template
- Processing template
√ Processing template
i Executing post init script
  ⏭️ Failed to generate debug.keystore file. You need to generate debug.keystore manually.
- Installing dependencies
√ Installing dependencies
- Initializing Git repository
√ Initializing Git repository


  Run instructions for Android:
    • Have an Android emulator running (quickest way to get started), or a device connected.
    • cd "path-to\example\hands-on\generated\HandsOnApp" && npx react-native run-android

  Run instructions for Windows:
    • See https://aka.ms/ReactNativeGuideWindows for the latest up-to-date instructions.


Reinstall using legacy-peer-deps for npm version 7 or later.

> postinstall
> run-s postinstall:*


> postinstall:patch-package
> patch-package

patch-package 8.0.0
Applying patches...
@expo/config-plugins@8.0.9 ✔
react-native-elements@3.4.3 ✔

Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    @expo/config-plugins@8.0.9

  applied to

    @expo/config-plugins@8.0.11

  At path

    node_modules/@expo/config-plugins

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package @expo/config-plugins

  to update the version in the patch file name and make this warning go away.

---
patch-package finished with 1 warning(s).

removed 4 packages, and audited 1524 packages in 4s

204 packages are looking for funding
  run `npm fund` for details

3 low severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.

> prebuild
> run-s build:plugin && expo prebuild --clean --no-install


> build:plugin
> rimraf config/plugin/build && tsc --build config/plugin

Warning! Your git working tree is dirty.
It's recommended to commit all your changes before proceeding, so you can revert the changes made by this command if necessary.
Git status is dirty but the command will continue because the terminal is not interactive.
- Clearing android
√ Cleared android code
- Creating native directory (./android)
√ Created native directory
- Updating package.json
√ Updated package.json | no changes
- Running prebuild
√ Finished prebuild
⚠️ CocoaPods is only supported on darwin machines
Reinitialized existing Git repository in path-to/example/hands-on/generated/HandsOnApp/.git/
[main a36a127] initial commit
 1 file changed, 42 insertions(+), 58 deletions(-)
[main 3a0de3e] apply 01-welcome.patch.
 4 files changed, 28 insertions(+), 33 deletions(-)
 delete mode 100644 src/screens/home/Home.tsx
 create mode 100644 src/screens/home/Welcome.tsx
[main 405d909] apply 02-stack-navigation.patch.
 6 files changed, 81 insertions(+), 3 deletions(-)
 create mode 100644 src/screens/auth/Login.tsx
 create mode 100644 src/screens/auth/index.ts
 create mode 100644 src/screens/todo/TodoBoard.tsx
 create mode 100644 src/screens/todo/index.ts
[main 62aba38] apply 03-condition-based-navigation.patch.
 10 files changed, 151 insertions(+), 47 deletions(-)
 create mode 100644 src/contexts/UserContext.tsx
 create mode 100644 src/navigation/AuthedStackNav.tsx
 create mode 100644 src/navigation/UnauthedStackNav.tsx
 create mode 100644 src/services/AuthService.ts
 create mode 100644 src/services/index.ts
[main ea4c4d7] apply 04-tab-navigation.patch.
 9 files changed, 89 insertions(+), 10 deletions(-)
 create mode 100644 src/navigation/MainTabNav.tsx
 create mode 100644 src/navigation/SettingsStackNav.tsx
 create mode 100644 src/navigation/TodoStackNav.tsx
 create mode 100644 src/screens/settings/UserSetting.tsx
 create mode 100644 src/screens/settings/index.ts
[main df3235b] apply 05-modal-screen.patch.
 4 files changed, 51 insertions(+), 3 deletions(-)
 create mode 100644 src/screens/todo/TodoForm.tsx
[main f7642a9] apply 06-login-screen.patch.
 2 files changed, 53 insertions(+), 10 deletions(-)
[main 523ca04] apply 07-virtual-keyboard-control.patch.
 1 file changed, 35 insertions(+), 25 deletions(-)
[main eba9c5f] apply 08-information-dialog.patch.
 1 file changed, 11 insertions(+), 2 deletions(-)
[main 1f8773b] apply 09-todo-list-screen.patch.
 8 files changed, 268 insertions(+), 8 deletions(-)
 create mode 100644 src/components/parts/index.ts
 create mode 100644 src/components/parts/todo/TodoFilter.tsx
 create mode 100644 src/components/parts/todo/TodoItem.tsx
 create mode 100644 src/components/parts/todo/TodoList.tsx
 create mode 100644 src/components/parts/todo/index.ts
 create mode 100644 src/services/TodoService.tsx
[main f392f82] apply 10-todo-form-screen.patch.
 1 file changed, 79 insertions(+), 6 deletions(-)
[main a6625de] apply 11-use-focus-effect.patch.
 1 file changed, 17 insertions(+), 15 deletions(-)
[main 4c7fb54] apply 12-common-component.patch.
 5 files changed, 38 insertions(+), 22 deletions(-)
 create mode 100644 src/components/basics/index.ts
 create mode 100644 src/components/basics/view/KeyboardView.tsx
 create mode 100644 src/components/basics/view/index.ts
[main 9fd9ddb] apply 13-logo.patch.
 6 files changed, 32 insertions(+)
 create mode 100644 src/@types/image.d.ts
 create mode 100644 src/assets/logo.png
 create mode 100644 src/components/basics/image/Logo.tsx
 create mode 100644 src/components/basics/image/index.ts
[main 93639aa] apply 22-generate-api-client.patch.
 14 files changed, 737 insertions(+)
 create mode 100644 openapitools.json
 create mode 100644 src/backend/config.ts
 create mode 100644 src/backend/generated-rest-client/.openapi-generator-ignore
 create mode 100644 src/backend/generated-rest-client/.openapi-generator/FILES
 create mode 100644 src/backend/generated-rest-client/.openapi-generator/VERSION
 create mode 100644 src/backend/generated-rest-client/apis/TodosApi.ts
 create mode 100644 src/backend/generated-rest-client/apis/index.ts
 create mode 100644 src/backend/generated-rest-client/index.ts
 create mode 100644 src/backend/generated-rest-client/models/NewTodo.ts
 create mode 100644 src/backend/generated-rest-client/models/Todo.ts
 create mode 100644 src/backend/generated-rest-client/models/TodoStatus.ts
 create mode 100644 src/backend/generated-rest-client/models/index.ts
 create mode 100644 src/backend/generated-rest-client/runtime.ts
 create mode 100644 src/backend/index.ts
[main be9939d] apply 23-call-rest-api.patch.
 1 file changed, 7 insertions(+), 64 deletions(-)
[main 87e2ce0] apply 24-display-getting-todo-list.patch.
 2 files changed, 36 insertions(+), 4 deletions(-)
[main f25b186] apply 25-display-updating-todo.patch.
 3 files changed, 41 insertions(+), 4 deletions(-)

> postinstall
> run-s postinstall:*


> postinstall:patch-package
> patch-package

patch-package 8.0.0
Applying patches...
@expo/config-plugins@8.0.9 ✔
react-native-elements@3.4.3 ✔

Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    @expo/config-plugins@8.0.9

  applied to

    @expo/config-plugins@8.0.11

  At path

    node_modules/@expo/config-plugins

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package @expo/config-plugins

  to update the version in the patch file name and make this warning go away.

---
patch-package finished with 1 warning(s).

added 15 packages, and audited 1539 packages in 5s

205 packages are looking for funding
  run `npm fund` for details

3 low severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.

> prebuild
> run-s build:plugin && expo prebuild --clean --no-install


> build:plugin
> rimraf config/plugin/build && tsc --build config/plugin

Warning! Your git working tree is dirty.
It's recommended to commit all your changes before proceeding, so you can revert the changes made by this command if necessary.
Git status is dirty but the command will continue because the terminal is not interactive.
- Clearing android
√ Cleared android code
- Creating native directory (./android)
√ Created native directory
- Updating package.json
√ Updated package.json | no changes
- Running prebuild
√ Finished prebuild
⚠️ CocoaPods is only supported on darwin machines
[main 57ffd17] update package-lock.json
 1 file changed, 165 insertions(+), 43 deletions(-)
[main b9cd891] rewritten the Backend Server IP address in src/backend/config.ts
 1 file changed, 1 insertion(+), 1 deletion(-)
Replaced the Backend Server IP address in src/backend/config.ts with [localhost].
Successfully created HandsOnApp.
```


## Other (messages to reviewers, concerns, etc.)

* templateのExpo SDKが古い51の件(最新は52)は別途対応します
* 関連PR: https://github.com/ws-4020/mobile-app-crib-notes/pull/1331